### PR TITLE
fix: remove duplicate Vuetify init causing color regression

### DIFF
--- a/apps/lp/src/main.js
+++ b/apps/lp/src/main.js
@@ -1,34 +1,10 @@
-/**
- * main.js
- *
- * Bootstraps Vuetify and other plugins then mounts the App`
- */
-
-// Components
 import App from "./App.vue";
-// Composables
 import { createApp } from "vue";
-import "vuetify/styles";
-import { createVuetify } from "vuetify";
-// Plugins
 import { registerPlugins } from "@/plugins";
 
 const app = createApp(App);
-// Vuetify
-const vuetify = createVuetify({});
-app.use(vuetify);
 registerPlugins(app);
 app.mount("#app");
-
-/* ここより以下の箇所は回収が必要*/
-//Vue2 Hammer
-import { VueHammer } from "vue2-hammer";
-import Hammer from "hammerjs";
-VueHammer.config.swipe = {
-  direction: Hammer.DIRECTION_HORIZONTAL,
-};
-app.config.productionTip = false;
-app.use(VueHammer);
 
 //Google Tag Manager
 import VueGtm from "vue-gtm";


### PR DESCRIPTION
## Summary
- `main.js` で `createVuetify({})`（空設定）と `registerPlugins`（カスタムテーマ入り）の2重初期化が発生していた
- Vue の `app.use()` は同一プラグインを1回しか登録しないため、先に登録された空のVuetifyが優先されカスタムカラーが無効に
- `vue2-hammer` も Vue2専用のため同時に削除

## Test plan
- [ ] デプロイ後にLPのカラー（primary: #182F43など）が正しく表示される
- [ ] ビルドが通ること ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)