### PR TITLE
chore(infra): Render Blueprint mode 化 + render.yaml 完全化 (#123)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,15 +1,31 @@
+# Render Blueprint 定義 — High Q LP
+# このファイルが Render Dashboard 設定の **真実の源** (Blueprint mode)。
+# Dashboard 側での個別変更は禁止し、すべて本ファイルへの PR 経由で管理する。
+# Blueprint Instance を作成すると Auto-sync で本ファイルの変更が即反映される。
+
 services:
   - type: web
     name: high-q-lp
     runtime: static
     rootDir: apps/lp
-    # corepack enable で root package.json の packageManager (pnpm@10.33.2) を強制。
-    # これにより pnpm.onlyBuiltDependencies (core-js, esbuild のみホワイトリスト) が
-    # 機能し、jsdom などの build script (wireit) が誤って実行されない
-    buildCommand: corepack enable && pnpm install --frozen-lockfile && pnpm build
-    staticPublishPath: dist
     branch: master
+
+    # ビルド方針:
+    # - corepack enable: root package.json の packageManager (pnpm@10.33.2) を強制
+    # - --prod: root package の devDependencies を install しない（本番不要）
+    # - --ignore-scripts: 全 lifecycle script (prepare/postinstall) を install 時にスキップ
+    #   jsdom v25 の prepare (convert-idl) や wireit 等の問題ある script が走らない事を保証
+    # - --frozen-lockfile: pnpm-lock.yaml に厳密従属
+    # CI (GitHub Actions) は別途フル install してテスト実行する想定。
+    buildCommand: corepack enable && pnpm install --prod --frozen-lockfile --ignore-scripts && pnpm build
+    staticPublishPath: dist
+
+    # 自動デプロイ設定:
+    # - master push で本番自動再ビルド
+    # - PR push で Preview 環境を自動起動
+    autoDeploy: true
     pullRequestPreviewsEnabled: true
+
     envVars:
       - key: NODE_VERSION
         value: "22"


### PR DESCRIPTION
## Summary
Render Dashboard と \`render.yaml\` の設定乖離が頻発（#114, #121）するため、Blueprint mode に切替えて yaml を真実の源にする。

## 変更内容

### 1. \`render.yaml\` 完全化
- **buildCommand** を最新に統一: \`corepack enable && pnpm install --prod --frozen-lockfile --ignore-scripts && pnpm build\`
  - \`--prod\` / \`--ignore-scripts\` は jsdom prepare 失敗 (#121) の根本対策
  - 本対応で **PR #122 の内容も取り込み** → PR #122 はクローズ予定
- **\`autoDeploy: true\`** を明示
  - これまで Dashboard 側のみで管理されていた Auto-Deploy 設定を yaml に
  - PR preview の auto trigger 不全（#121 で発覚）の根本対策
- **ヘッダコメント**で Blueprint mode 運用を明文化（Dashboard 直編集禁止）

## オーナー手動作業（マージ後）

### Step 1: Blueprint Instance を作成
1. Render Dashboard → **Blueprints** → **New Blueprint Instance**
2. リポジトリ: \`High-Q/high-q-volleyball\`
3. branch: \`master\`
4. Render が \`render.yaml\` を読んで、既存 \`high-q-lp\` サービスとの sync を提案
5. **既存サービスと sync** を選択（新規作成しない）

### Step 2: Auto-sync を ON
1. Blueprint の Settings で **Auto-sync** を **Enabled** に
2. 以後、render.yaml への push が即 Dashboard に反映される

### Step 3: 動作確認
1. yaml を軽微に変更（コメント追加等）して push
2. Render Dashboard で Auto-sync が trigger されるか確認
3. Build Command 等が yaml と一致しているか確認

## 期待効果
- Dashboard 設定の二重管理を解消
- yaml 変更の即時反映
- PR Preview の auto trigger も正しく動作

## Test plan
- [ ] CI: lint / typecheck / test / build パス（render.yaml のみ変更なので影響極小）
- [ ] マージ後、Render が auto-deploy で本番再ビルド成功
- [ ] Blueprint Instance 作成・Auto-sync 有効化（オーナー手動）
- [ ] 後続 PR で yaml 変更が Dashboard に反映されることを確認

Closes #123
PR #122 をクローズ予定（本 PR が上位互換）

🤖 Generated with [Claude Code](https://claude.com/claude-code)