### PR TITLE
chore(infra): Blueprint で既存 high-q-volleyball を取り込み・name 一致化 (#125)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,11 +1,13 @@
 # Render Blueprint 定義 — High Q LP
 # このファイルが Render Dashboard 設定の **真実の源** (Blueprint mode)。
 # Dashboard 側での個別変更は禁止し、すべて本ファイルへの PR 経由で管理する。
-# Blueprint Instance を作成すると Auto-sync で本ファイルの変更が即反映される。
+# Blueprint Instance の Auto-sync で本ファイルの変更が即反映される。
 
 services:
   - type: web
-    name: high-q-lp
+    # name は既存サービスと一致させること（Blueprint は name で既存 service を識別する）。
+    # ここを変えると新規サービスが二重作成される（#125 で経験済）。
+    name: high-q-volleyball
     runtime: static
     rootDir: apps/lp
     branch: master
@@ -21,10 +23,12 @@ services:
     staticPublishPath: dist
 
     # 自動デプロイ設定:
-    # - master push で本番自動再ビルド
-    # - PR push で Preview 環境を自動起動
-    autoDeploy: true
-    pullRequestPreviewsEnabled: true
+    # - autoDeployTrigger: checksPass で「CI 通過後にデプロイ」を実現
+    #   旧フィールド autoDeploy は非推奨、後継 autoDeployTrigger を使う
+    # - previews.generation: automatic で全 PR に Preview 環境を自動起動
+    autoDeployTrigger: checksPass
+    previews:
+      generation: automatic
 
     envVars:
       - key: NODE_VERSION


### PR DESCRIPTION
## Summary
PR #124 で Blueprint mode 化したが \`name: high-q-lp\` が既存サービス \`high-q-volleyball\` と一致しなかったため、Render が新規サービスとして \`high-q-lp.onrender.com\` を作成（二重サービス状態）。Render docs に基づき、name 一致で既存サービスを取り込む。

## render.yaml の変更
| 項目 | 変更前 | 変更後 |
|---|---|---|
| name | \`high-q-lp\` | **\`high-q-volleyball\`** |
| 自動デプロイ | \`autoDeploy: true\` | **\`autoDeployTrigger: checksPass\`** |
| PR Preview | \`pullRequestPreviewsEnabled: true\` | **\`previews: generation: automatic\`** |

## 設定差分の保証
旧サービス Dashboard と新 yaml は **完全一致**:

| 項目 | Dashboard | yaml |
|---|---|---|
| name | high-q-volleyball | ✅ |
| branch | master | ✅ |
| rootDir | apps/lp | ✅ |
| buildCommand | \`corepack...--prod...--ignore-scripts && pnpm build\` | ✅ |
| publishDir | dist | ✅ |
| Auto-Deploy | After CI Checks Pass | ✅ \`autoDeployTrigger: checksPass\` |
| PR Previews | Automatic | ✅ \`previews.generation: automatic\` |
| envVars | NODE_VERSION=22 | ✅ |

→ **差分ゼロ → Blueprint sync で旧サービスに上書きしても挙動変化なし**。

## サイトダウンが起きない理由
- name 変更は **設定のみの更新**で build trigger されない
- 旧サービスの URL/コンテンツは無傷
- 新サービスは別 URL (\`high-q-lp.onrender.com\`) なので削除しても旧 live に影響なし

## オーナー手動作業（マージ後）
1. **新サービス \`high-q-lp\` を Render Dashboard で削除**（同名衝突を防ぐ）
2. Blueprint Manual Sync をクリック
3. 旧サービス \`high-q-volleyball\` Settings に「Linked to Blueprint」表示を確認
4. \`https://high-q-volleyball.onrender.com\` の live を確認
5. Build Command 等が render.yaml と完全一致していることを確認

## ロールバック
- yaml を \`name: high-q-lp\` に revert すれば元の二重サービス状態に戻る
- 旧サービスは終始触らないので live は維持

## Test plan
- [ ] CI: lint / typecheck / test / build パス（render.yaml のみ変更で影響極小）
- [ ] マージ後、Blueprint Manual Sync で旧サービスが取り込まれる
- [ ] 旧サービス live 維持
- [ ] 新サービス削除完了

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)