### PR TITLE
fix(infra): autoDeployTrigger を commit に戻して自動デプロイ復旧 (#128)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -23,10 +23,12 @@ services:
     staticPublishPath: dist
 
     # 自動デプロイ設定:
-    # - autoDeployTrigger: checksPass で「CI 通過後にデプロイ」を実現
-    #   旧フィールド autoDeploy は非推奨、後継 autoDeployTrigger を使う
+    # - autoDeployTrigger: commit で commit ごとに即デプロイ
+    #   本来は checksPass にして CI 通過後にデプロイしたいが、Issue #80 の
+    #   GitHub Actions CI が未設定の間 checks が永久に走らず stuck するため
+    #   暫定で commit。#80 完了後に別 PR で checksPass に戻す（#128 参照）
     # - previews.generation: automatic で全 PR に Preview 環境を自動起動
-    autoDeployTrigger: checksPass
+    autoDeployTrigger: commit
     previews:
       generation: automatic
 


### PR DESCRIPTION
## 症状（緊急）
Render の master 自動デプロイ + PR Preview が trigger されない。

## 原因
PR #126 で \`autoDeployTrigger: checksPass\` を設定したが、GitHub Actions CI が未設定のため checks が走らず、checksPass が永久に成立せずデプロイ stuck。

## 修正
\`autoDeployTrigger: checksPass\` → **\`autoDeployTrigger: commit\`** に変更（暫定）。
コメントで Issue #80 (CI 構築) 完了後に checksPass に戻す旨を明記。

## 後続
1. 本 PR マージ → master 自動デプロイ復旧
2. Issue #80 で GitHub Actions CI を構築
3. CI 完了後、別 PR で \`checksPass\` に戻す

## Test plan
- [ ] マージ後、master の自動デプロイが trigger される
- [ ] 後続 PR で Preview 自動 trigger される

Closes #128
関連: #80 (CI 構築)

🤖 Generated with [Claude Code](https://claude.com/claude-code)