### PR TITLE
docs(claude-md): Issue 新規作成時の親 Epic 配置提案ルールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,19 @@ gh issue create --title "feat: ..." --label "enhancement"
 git checkout -b feature/<issue番号>-<kebab-case-summary>
 ```
 
+### Issue 新規作成時のルール（親 Epic 配置の提案必須）
+
+Issue を新規作成する前に、**必ず親 Issue (Epic) との関係を翔太郎くんに提案する**:
+
+1. 起点となる Issue / Epic がある場合は「**#xx の下に配置**」と明示提案
+2. 関連 Epic が複数 or 不明な場合は候補を提示して確認
+3. 完全に独立した新規タスクなら「親 Issue なし」と明示
+
+提案フォーマット例:
+> 「以下の Issue を作成します、配置: **Epic #75 の下**」
+
+承認後、Issue 本文の最終行に `Epic: #<親番号>` を記載する。これにより GitHub 上で Epic から後続 Issue を辿れる状態を保つ。後続 Issue を分離する際（例: スコープ縮小で別 Issue へ移譲する場合）は、元の Issue が紐付いていた Epic を踏襲することを基本方針とする。
+
 ### マージ後の後始末（必須）
 
 ```bash


### PR DESCRIPTION
## Summary

- CLAUDE.md Pillar 1 に「Issue 新規作成時の親 Epic 配置提案ルール」を追加
- Issue 作成前に必ず親 Epic との関係（`#xx の下に配置`）を翔太郎くんに提案するルール
- 後続 Issue 分離時は元の Issue が紐付いていた Epic を踏襲する方針を明記
- 取りこぼし対応: #139 / #140 の本文末尾に `Epic: #75` を追記済み（GitHub 側で完了済み、本 PR の差分には含まない）

## Why

#138 (render-multi-app-deploy) のスコープ縮小に伴い、後続 Issue として #139 / #140 を作成した際、Epic #75 への紐付けが取りこぼれた。元の Issue #81 は `Epic: #75` 配下だったため、後続も同 Epic 配下に置くべきだった。同じ取りこぼしを再発させないためルール化。

## Test plan

- [ ] CLAUDE.md の差分が意図通り
- [ ] CI 全パス（typecheck / lint / test / build）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
