### PR TITLE
chore(lp): build tool を devDependencies に戻す (#178)

### DIFF
--- a/apps/lp/package.json
+++ b/apps/lp/package.json
@@ -15,10 +15,7 @@
     "@high-q/design-tokens": "workspace:*",
     "@tanstack/vue-query": "^5.100.1",
     "@vitejs/plugin-vue": "^5.0.2",
-    "sass": "~1.69.6",
-    "unplugin-vue-components": "^0.26.0",
     "vite": "^5.0.10",
-    "vite-plugin-vuetify": "^2.0.1",
     "vue": "^3.4.3",
     "vuetify": "^3.4.0"
   },
@@ -30,6 +27,9 @@
     "eslint-plugin-vuetify": "^2.1.1",
     "jsdom": "^25.0.0",
     "msw": "^2.6.0",
+    "sass": "~1.69.6",
+    "unplugin-vue-components": "^0.26.0",
+    "vite-plugin-vuetify": "^2.0.1",
     "vitest": "^2.1.9",
     "vue-eslint-parser": "^9.3.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,18 +105,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^5.0.2
         version: 5.2.4(vite@5.4.21(@types/node@25.6.0)(sass@1.69.7))(vue@3.5.33(typescript@5.9.3))
-      sass:
-        specifier: ~1.69.6
-        version: 1.69.7
-      unplugin-vue-components:
-        specifier: ^0.26.0
-        version: 0.26.0(@babel/parser@7.29.2)(rollup@4.60.2)(vue@3.5.33(typescript@5.9.3))
       vite:
         specifier: ^5.0.10
         version: 5.4.21(@types/node@25.6.0)(sass@1.69.7)
-      vite-plugin-vuetify:
-        specifier: ^2.0.1
-        version: 2.1.3(vite@5.4.21(@types/node@25.6.0)(sass@1.69.7))(vue@3.5.33(typescript@5.9.3))(vuetify@3.12.5)
       vue:
         specifier: ^3.4.3
         version: 3.5.33(typescript@5.9.3)
@@ -145,6 +136,15 @@ importers:
       msw:
         specifier: ^2.6.0
         version: 2.13.6(@types/node@25.6.0)(typescript@5.9.3)
+      sass:
+        specifier: ~1.69.6
+        version: 1.69.7
+      unplugin-vue-components:
+        specifier: ^0.26.0
+        version: 0.26.0(@babel/parser@7.29.2)(rollup@4.60.2)(vue@3.5.33(typescript@5.9.3))
+      vite-plugin-vuetify:
+        specifier: ^2.0.1
+        version: 2.1.3(vite@5.4.21(@types/node@25.6.0)(sass@1.69.7))(vue@3.5.33(typescript@5.9.3))(vuetify@3.12.5)
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.69.7)


### PR DESCRIPTION
## Summary

#84 で Render PR Preview の鶏卵問題（PR ブランチの render.yaml が Blueprint Auto-sync まで反映されない仕様）を抜けるため、apps/lp/package.json で **build tool 3 package を一時的に dependencies に置いていた**。#177 のマージで master の render.yaml から `--prod` が外れ、Blueprint Auto-sync で本番 service にも反映済みのため、本来の慣習通り devDependencies に戻す。

### 戻す package
- `unplugin-vue-components`
- `vite-plugin-vuetify`
- `sass`

## なぜやるか

- Node.js / Vue / Vite エコシステム慣習: dependencies = runtime / devDependencies = build/test
- npm audit / Snyk / SBOM ツールが build tool を production dep として誤検出するのを防ぐ
- 半年後に「なぜ build tool が dependencies？」と混乱しないため

## Test plan

- [x] ローカル `pnpm --filter @high-q/lp build` 通過確認
- [ ] CI 全 pass（GitHub Actions）
- [ ] Render PR Preview ビルド成功（master の render.yaml `--prod` 削除が反映されているはず）

## 背景の詳細

#84 PR #177 のスレッドで、Render Static Site の自動 npm install と pnpm workspaces (`workspace:*`) の不一致を解決するため複数手を打った:

1. Dashboard で `SKIP_INSTALL_DEPS=true` 手動追加（即時反映）
2. render.yaml から `--prod` 削除（master マージ後に Blueprint Auto-sync で反映）
3. apps/lp/package.json で build tool を dependencies に移動（鶏卵問題の即時 workaround）

本 PR は (3) の workaround を撤収するもの。(1)(2) で本質的な問題は解消済み。

Closes #178
Refs #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)