### PR TITLE
fix(e2e): #231 LP の e2e モックを Supabase 経路に対応 (master CI を緑にして Render デプロイ発火)

### DIFF
--- a/e2e/lp/_helpers/eventApi.ts
+++ b/e2e/lp/_helpers/eventApi.ts
@@ -1,5 +1,21 @@
 import type { Page } from '@playwright/test'
 
+/**
+ * LP の E2E で使う Supabase events 取得モック。
+ *
+ * #228 以降 LP のイベント取得は Supabase 経由になったため、PostgREST 形式
+ * (`/rest/v1/events?...`) を route で横取りし、配列を直接返す。
+ * fixture shape は旧 AWS API のものを維持（テスト側の参照プロパティを
+ * 変えないため）し、本ヘルパー内部で Supabase レスポンス shape へ変換する:
+ *
+ *   title       → name
+ *   start_time  → start_at
+ *   end_time    → end_at
+ *   location    → venues.name
+ */
+
+import type { Route } from '@playwright/test'
+
 export type EventFixture = {
   id: string | number
   title: string
@@ -8,12 +24,22 @@ export type EventFixture = {
   location: string
 }
 
+function toSupabaseRow(e: EventFixture) {
+  return {
+    id: e.id,
+    name: e.title,
+    start_at: e.start_time,
+    end_at: e.end_time,
+    venues: { name: e.location },
+  }
+}
+
 export async function mockEventApi(page: Page, events: EventFixture[]): Promise<void> {
-  await page.route('**/beta/event', async (route) => {
+  await page.route(/\/rest\/v[0-9]+\/events/, async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ body: JSON.stringify(events) }),
+      body: JSON.stringify(events.map(toSupabaseRow)),
     })
   })
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -68,6 +68,12 @@ export default defineConfig({
       url: LP_URL,
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
+      env: {
+        // LP も Supabase に接続するため、admin / reservation と同じ DUMMY 値を build 時に流す。
+        // 実通信は mockEventApi が route で横取りするため、本値はバンドルに埋め込まれるだけ。
+        VITE_SUPABASE_URL: E2E_DUMMY_SUPABASE_URL,
+        VITE_SUPABASE_PUBLISHABLE_KEY: E2E_DUMMY_SUPABASE_KEY,
+      },
     },
     {
       command:


### PR DESCRIPTION
## Summary

PR #231（LP の Supabase 切替）マージ後、master CI の **LP e2e 2 件** が失敗し、`autoDeployTrigger: checksPass` が発火せず Render の本番 LP 再デプロイが止まっていた。AWS endpoint をモックしていた古いヘルパーが残っていたため。

## 修正内容

- **`playwright.config.ts`**: LP webServer に admin / reservation と同じ DUMMY Supabase env vars を追加（`E2E_DUMMY_SUPABASE_URL` / `E2E_DUMMY_SUPABASE_KEY`）→ build 時に Supabase client が初期化できる
- **`e2e/lp/_helpers/eventApi.ts`**: mock 対象を `**/beta/event` から `/rest/v[0-9]+/events` に変更。fixture shape (旧 AWS) は維持し、ヘルパー内で Supabase レスポンス shape に変換

テスト本体 (`e2e/lp/event-calendar.e2e.ts`) は無変更。

## Test plan

- [x] ローカル `pnpm exec playwright test --project=lp` で **3/3 件 green**
- [ ] CI の master で本 PR マージ後 e2e 全パス → Render auto deploy 発火
- [ ] 本番 LP URL でカレンダーが prd Supabase のイベントを表示することを確認

Refs #228 / PR #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
