### PR TITLE
feat(lp): #243 CTA 動線を予約サイト商用稼働前提に再構成

### DIFF
--- a/apps/lp/src/App.vue
+++ b/apps/lp/src/App.vue
@@ -61,6 +61,19 @@ onUnmounted(() => {
 </script>
 
 <style>
+html {
+  scroll-behavior: smooth;
+}
+
+/* sticky header 分のオフセットで、アンカー遷移時に見出しが隠れないようにする */
+[id="about-heading"],
+[id="features-heading"],
+[id="flow-heading"],
+[id="event-list-heading"],
+[id="faq-heading"] {
+  scroll-margin-top: 80px;
+}
+
 .lp-app {
   background: var(--hq-color-paper);
   color: var(--hq-color-ink);

--- a/apps/lp/src/shared/config/sns.js
+++ b/apps/lp/src/shared/config/sns.js
@@ -1,4 +1,6 @@
-export const LINE_OPEN_CHAT_URL = 'https://line.me/ti/g2/highq-volley'
+export const LINE_OPEN_CHAT_URL = 'https://line.me/ti/g2/f6YscOz1mh7dnUWX_T4fG3mlqzppz7EoC6-k9A?utm_source=invitation&utm_medium=link_copy&utm_campaign=default'
 
-export const X_URL = 'https://x.com/highq_volley'
-export const X_HANDLE = '@highq_volley'
+export const LINE_OPEN_CHAT_NAME = '社会人バレーボールサークル High Q'
+
+export const X_URL = 'https://x.com/HighQ_volleybal'
+export const X_HANDLE = '@HighQ_volleybal'

--- a/apps/lp/src/widgets/event-list/ui/EventList.vue
+++ b/apps/lp/src/widgets/event-list/ui/EventList.vue
@@ -23,12 +23,7 @@
     </div>
     <ul v-else class="event-list__items">
       <li v-for="event in events" :key="event.id" class="event-list__item">
-        <a
-          v-if="urlFor(event.id)"
-          :href="urlFor(event.id)"
-          class="event-card"
-          :data-event-id="event.id"
-        >
+        <article class="event-card" :data-event-id="event.id">
           <div class="event-card__date">
             <div class="event-card__month">{{ event.monthLabel }}</div>
             <div class="event-card__day">{{ event.dayLabel }}</div>
@@ -39,21 +34,16 @@
             <div class="event-card__meta">{{ event.time }}</div>
             <div class="event-card__meta">{{ event.location }}</div>
           </div>
-          <span class="event-card__arrow" aria-hidden="true">›</span>
-        </a>
-        <div v-else class="event-card event-card--disabled">
-          <div class="event-card__date">
-            <div class="event-card__month">{{ event.monthLabel }}</div>
-            <div class="event-card__day">{{ event.dayLabel }}</div>
-            <div class="event-card__dow">{{ event.dowLabel }}</div>
-          </div>
-          <div class="event-card__body">
-            <div class="event-card__title">{{ event.title }}</div>
-            <div class="event-card__meta">{{ event.time }}</div>
-            <div class="event-card__meta">{{ event.location }}</div>
-            <div class="event-card__hint">予約受付準備中</div>
-          </div>
-        </div>
+          <a
+            :href="urlFor(event.id)"
+            class="event-card__cta"
+            :data-event-id="event.id"
+            :data-testid="`event-card-cta-${event.id}`"
+          >
+            予約する
+            <span aria-hidden="true">›</span>
+          </a>
+        </article>
       </li>
     </ul>
   </section>
@@ -152,22 +142,12 @@ function urlFor(id) {
 .event-card {
   display: flex;
   gap: 16px;
-  align-items: stretch;
+  align-items: center;
   background: var(--hq-color-paper-warm);
   border: 1px solid var(--hq-color-hairline);
   border-radius: 4px;
   padding: 18px;
-  text-decoration: none;
   color: inherit;
-  transition: border-color 150ms ease, transform 150ms ease;
-}
-
-.event-card:hover:not(.event-card--disabled) {
-  border-color: rgba(31, 29, 26, 0.24);
-}
-
-.event-card--disabled {
-  opacity: 0.85;
 }
 
 .event-card__date {
@@ -222,18 +202,31 @@ function urlFor(id) {
   line-height: 1.7;
 }
 
-.event-card__hint {
-  font-family: var(--hq-font-mono);
-  font-size: 9px;
-  letter-spacing: 0.15em;
-  color: var(--hq-color-muted);
-  margin-top: 8px;
+.event-card__cta {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 16px;
+  border-radius: var(--hq-radius-pill);
+  background: var(--hq-color-ink);
+  color: var(--hq-color-paper);
+  font-family: var(--hq-font-jp);
+  font-size: 12.5px;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-decoration: none;
+  min-height: 36px;
+  white-space: nowrap;
+  transition: opacity 120ms ease;
 }
 
-.event-card__arrow {
-  font-family: var(--hq-font-jp);
-  font-size: 20px;
-  color: var(--hq-color-muted);
-  align-self: center;
+.event-card__cta:hover {
+  opacity: 0.88;
+}
+
+.event-card__cta:focus-visible {
+  outline: 2px solid var(--hq-color-ink);
+  outline-offset: 2px;
 }
 </style>

--- a/apps/lp/src/widgets/final-cta/ui/FinalCtaSection.vue
+++ b/apps/lp/src/widgets/final-cta/ui/FinalCtaSection.vue
@@ -14,9 +14,9 @@
         まずは1回、<br />見学だけでも。
       </h2>
       <p class="final-cta__lead">
-        予約サイトは現在準備中です。<br />
-        まずは LINE オープンチャットから<br />
-        お気軽にご連絡ください。
+        月1〜2回、土日祝に開催しています。<br />
+        LINE オープンチャットで次回告知が届きます。<br />
+        不安があれば、まずは質問だけでも。
       </p>
 
       <div class="final-cta__actions">
@@ -27,28 +27,24 @@
           class="final-cta__btn-primary"
           data-testid="final-cta-line"
         >
-          LINE オープンチャットで連絡
+          LINE で相談・告知を受け取る
         </a>
+        <p class="final-cta__connector">または、まずは</p>
         <a
-          :href="X_URL"
-          target="_blank"
-          rel="noopener noreferrer"
+          href="#event-list-heading"
           class="final-cta__btn-secondary"
-          data-testid="final-cta-x"
+          data-testid="final-cta-event-list"
         >
-          X {{ X_HANDLE }} でDM
-          <span aria-hidden="true">↗</span>
+          次回イベントを見る
         </a>
       </div>
-
-      <p class="final-cta__note">所要 1分 ・ キャンセル無料</p>
     </div>
   </section>
 </template>
 
 <script setup>
 import { Photo } from '@high-q/ui'
-import { LINE_OPEN_CHAT_URL, X_URL, X_HANDLE } from '@shared/config/sns'
+import { LINE_OPEN_CHAT_URL } from '@shared/config/sns'
 </script>
 
 <style scoped>
@@ -112,6 +108,14 @@ import { LINE_OPEN_CHAT_URL, X_URL, X_HANDLE } from '@shared/config/sns'
   gap: 10px;
 }
 
+.final-cta__connector {
+  margin: 4px 0;
+  text-align: center;
+  font-family: var(--hq-font-jp);
+  font-size: 12px;
+  opacity: 0.7;
+}
+
 .final-cta__btn-primary {
   display: inline-flex;
   align-items: center;
@@ -171,11 +175,4 @@ import { LINE_OPEN_CHAT_URL, X_URL, X_HANDLE } from '@shared/config/sns'
   outline-offset: 2px;
 }
 
-.final-cta__note {
-  text-align: center;
-  font-family: var(--hq-font-jp);
-  font-size: 12px;
-  opacity: 0.7;
-  margin: 12px 0 0;
-}
 </style>

--- a/apps/lp/src/widgets/hero-first/ui/HeroFirst.vue
+++ b/apps/lp/src/widgets/hero-first/ui/HeroFirst.vue
@@ -22,14 +22,20 @@
           ちょうどいい温度のバレーボールです。
         </p>
         <div class="hero-first__cta">
-          <Button
-            variant="primary"
-            size="md"
-            class="hero-first__cta-btn"
-            @click="onTrialClick"
+          <a
+            href="#event-list-heading"
+            class="hero-first__cta-link"
+            data-testid="hero-event-list-cta"
           >
-            体験参加してみる
-          </Button>
+            <Button
+              variant="primary"
+              size="md"
+              class="hero-first__cta-btn"
+              tabindex="-1"
+            >
+              イベントを見る
+            </Button>
+          </a>
         </div>
         <p class="hero-first__meta">所要 1分 ・ 月1〜2回開催 ・ 参加費 500円〜</p>
       </div>
@@ -39,12 +45,6 @@
 
 <script setup>
 import { Photo, Button } from '@high-q/ui'
-import { reservationTopUrl } from '@shared/config/reservation'
-
-function onTrialClick() {
-  const url = reservationTopUrl()
-  if (url) window.location.href = url
-}
 </script>
 
 <style scoped>
@@ -121,6 +121,11 @@ function onTrialClick() {
 
 .hero-first__cta {
   margin-top: 22px;
+}
+
+.hero-first__cta-link {
+  display: block;
+  text-decoration: none;
 }
 
 .hero-first__cta-btn {

--- a/apps/lp/src/widgets/next-session-strip/ui/NextSessionStrip.vue
+++ b/apps/lp/src/widgets/next-session-strip/ui/NextSessionStrip.vue
@@ -1,12 +1,6 @@
 <template>
   <aside class="next-strip" aria-label="次回開催">
-    <component
-      :is="targetUrl ? 'a' : 'div'"
-      :href="targetUrl || undefined"
-      class="next-strip__row"
-      :class="{ 'next-strip__row--link': !!targetUrl }"
-      :data-testid="targetUrl ? 'next-session-strip-link' : 'next-session-strip-static'"
-    >
+    <div class="next-strip__row">
       <span class="next-strip__tag" :class="{ 'next-strip__tag--muted': !nextEvent }">NEXT</span>
 
       <div class="next-strip__body">
@@ -29,8 +23,16 @@
         </template>
       </div>
 
-      <span v-if="targetUrl" class="next-strip__arrow" aria-hidden="true">予約 ›</span>
-    </component>
+      <a
+        v-if="nextEvent"
+        :href="targetUrl"
+        class="next-strip__cta"
+        data-testid="next-session-cta"
+      >
+        予約する
+        <span aria-hidden="true">›</span>
+      </a>
+    </div>
   </aside>
 </template>
 
@@ -38,14 +40,12 @@
 import { computed } from 'vue'
 import { useNextSession } from '../model/useNextSession'
 import { reservationEventUrl } from '@shared/config/reservation'
-import { LINE_OPEN_CHAT_URL } from '@shared/config/sns'
 
 const { nextEvent, isPending, isError } = useNextSession()
 
 const targetUrl = computed(() => {
   if (!nextEvent.value) return ''
-  const url = reservationEventUrl(nextEvent.value.id)
-  return url || LINE_OPEN_CHAT_URL
+  return reservationEventUrl(nextEvent.value.id)
 })
 
 const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土']
@@ -90,22 +90,6 @@ function formatTimeLocation(event) {
   gap: 14px;
   padding: 14px 24px;
   padding-inline: max(24px, calc((100% - 880px) / 2));
-  text-decoration: none;
-  color: inherit;
-}
-
-.next-strip__row--link {
-  cursor: pointer;
-  transition: background 150ms ease;
-}
-
-.next-strip__row--link:hover {
-  background: rgba(247, 243, 234, 0.04);
-}
-
-.next-strip__row--link:focus-visible {
-  outline: 2px solid var(--hq-color-accent);
-  outline-offset: -2px;
 }
 
 .next-strip__tag {
@@ -158,16 +142,30 @@ function formatTimeLocation(event) {
   text-overflow: ellipsis;
 }
 
-.next-strip__arrow {
+.next-strip__cta {
   flex-shrink: 0;
-  font-family: var(--hq-font-mono);
-  font-size: 10px;
-  letter-spacing: 0.15em;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 14px;
+  border-radius: var(--hq-radius-pill);
+  background: var(--hq-color-accent);
   color: var(--hq-color-paper);
-  opacity: 0.85;
+  font-family: var(--hq-font-jp);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-decoration: none;
+  min-height: 32px;
+  transition: opacity 120ms ease;
 }
 
-.next-strip__row--link:hover .next-strip__arrow {
-  opacity: 1;
+.next-strip__cta:hover {
+  opacity: 0.88;
+}
+
+.next-strip__cta:focus-visible {
+  outline: 2px solid var(--hq-color-paper);
+  outline-offset: 2px;
 }
 </style>

--- a/apps/lp/vite.config.js
+++ b/apps/lp/vite.config.js
@@ -31,6 +31,12 @@ export default defineConfig({
       "@shared":   fileURLToPath(new URL("./src/shared",    import.meta.url)),
     },
   },
+  // ローカル開発時のポートを 5173 で固定し、reservation (5174) との
+  // 衝突を防ぐ。strictPort により空きポートへの自動フォールバックは禁止。
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
   // モノレポ root の .env.* を共通参照する（envDir）。
   // 関連: openspec/specs/env-management/spec.md
   envDir: path.resolve(__dirname, "../.."),

--- a/apps/reservation/vite.config.ts
+++ b/apps/reservation/vite.config.ts
@@ -12,6 +12,13 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  // ローカル開発時のポートを固定し、LP の .env.local から
+  // VITE_RESERVATION_URL=http://localhost:5174 で安定参照できるようにする。
+  // LP dev は 5173 (Vite デフォルト)、reservation dev は 5174 に分ける。
+  server: {
+    port: 5174,
+    strictPort: true,
+  },
   // モノレポ root の .env.* を共通参照する（envDir）。
   // 関連: openspec/specs/env-management/spec.md（本 change マージ後）
   envDir: path.resolve(__dirname, '../..'),

--- a/e2e/lp/cta-links.e2e.ts
+++ b/e2e/lp/cta-links.e2e.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test'
+import { mockEventApi } from './_helpers/eventApi'
+
+test.describe('LP CTA リンク先', () => {
+  test('Hero CTA は #event-list-heading へアンカー遷移する', async ({ page }) => {
+    await mockEventApi(page, [])
+    await page.goto('/')
+
+    const hero = page.getByTestId('hero-event-list-cta')
+    await expect(hero).toBeVisible()
+    await expect(hero).toHaveAttribute('href', '#event-list-heading')
+  })
+
+  test('Final CTA primary は LINE オープンチャットを target=_blank で開く', async ({ page }) => {
+    await mockEventApi(page, [])
+    await page.goto('/')
+
+    const line = page.getByTestId('final-cta-line')
+    await expect(line).toBeAttached()
+    const href = await line.getAttribute('href')
+    expect(href).toMatch(/^https:\/\/line\.me\/ti\/g2\//)
+    await expect(line).toHaveAttribute('target', '_blank')
+    await expect(line).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  test('Final CTA secondary は #event-list-heading へアンカー遷移する', async ({ page }) => {
+    await mockEventApi(page, [])
+    await page.goto('/')
+
+    const second = page.getByTestId('final-cta-event-list')
+    await expect(second).toBeAttached()
+    await expect(second).toHaveAttribute('href', '#event-list-heading')
+  })
+
+  test('Final CTA に旧 X DM ボタンと予約サイト直行ボタンが存在しない', async ({ page }) => {
+    await mockEventApi(page, [])
+    await page.goto('/')
+
+    // X DM ボタンが撤去されている
+    await expect(page.getByTestId('final-cta-x')).toHaveCount(0)
+
+    // Final CTA セクション内に reservation URL を直接 href に持つ <a> が無い
+    const reservationUrl = process.env.VITE_RESERVATION_URL ?? 'http://localhost:4175'
+    const finalCta = page.locator('section[aria-labelledby="final-cta-heading"]')
+    const directReservationLinks = finalCta.locator(`a[href^="${reservationUrl}"]`)
+    await expect(directReservationLinks).toHaveCount(0)
+  })
+
+  test('next-session 帯は予約 URL へ直行する（LINE fallback しない）', async ({ page }) => {
+    const startIso = new Date(Date.now() + 86_400_000).toISOString()
+    const endIso = new Date(Date.now() + 86_400_000 + 7_200_000).toISOString()
+    await mockEventApi(page, [
+      {
+        id: 'evt-next-001',
+        title: '次回練習',
+        start_time: startIso,
+        end_time: endIso,
+        location: '江東区スポーツセンター',
+      },
+    ])
+    await page.goto('/')
+
+    const cta = page.getByTestId('next-session-cta')
+    await expect(cta).toBeVisible()
+    const href = await cta.getAttribute('href')
+    // 予約 URL は base + /events/<id>。LINE オープンチャットへ fallback していない
+    expect(href).not.toMatch(/^https:\/\/line\.me\//)
+    expect(href).toMatch(/\/events\/evt-next-001$/)
+  })
+})

--- a/e2e/lp/event-list.e2e.ts
+++ b/e2e/lp/event-list.e2e.ts
@@ -36,17 +36,17 @@ test.describe('LP EventList & NextSessionStrip', () => {
     const list = page.getByTestId('event-list')
     await expect(list).toBeVisible()
 
-    // 1 枚目のカードの予約 URL は reservation 側 /events/evt-001 で終わる
-    const firstCard = list.locator('.event-card').first()
-    await expect(firstCard).toBeVisible()
-    const href = await firstCard.getAttribute('href')
+    // 1 枚目のカードの予約ボタンが reservation 側 /events/evt-001 を指す
+    const firstCta = page.getByTestId('event-card-cta-evt-001')
+    await expect(firstCta).toBeVisible()
+    const href = await firstCta.getAttribute('href')
     expect(href).toBeTruthy()
     expect(href!).toMatch(/\/events\/evt-001$/)
 
-    // 次回開催帯のリンクも /events/evt-001 を指す
-    const nextLink = page.getByTestId('next-session-strip-link')
-    await expect(nextLink).toBeVisible()
-    const nextHref = await nextLink.getAttribute('href')
+    // 次回開催帯の予約ボタンも /events/evt-001 を指す
+    const nextCta = page.getByTestId('next-session-cta')
+    await expect(nextCta).toBeVisible()
+    const nextHref = await nextCta.getAttribute('href')
     expect(nextHref!).toMatch(/\/events\/evt-001$/)
   })
 

--- a/openspec/changes/archive/2026-05-14-lp-cta-reservation-first/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-14-lp-cta-reservation-first/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-13

--- a/openspec/changes/archive/2026-05-14-lp-cta-reservation-first/design.md
+++ b/openspec/changes/archive/2026-05-14-lp-cta-reservation-first/design.md
@@ -1,0 +1,196 @@
+## Context
+
+LP の現状 CTA は「予約サイト準備中」前提で、final-cta では LINE が Primary、X DM が Secondary、hero CTA は予約サイトトップに直行する設計。予約サイト・admin が MVP1 完了し商用稼働した今、これらは前提が崩れている。
+
+ただし「予約サイト直行 → イベント 0 件 → 会員登録だけで離脱 → 不満」は CVR と満足度の両方を下げるワーストパターン。LP 内に `EventList` widget があり、ここでイベント有無を必ず確認できる構造になっているため、**全 CTA は event-list を経由する** 設計に統一する。予約サイトへの遷移は各イベントカード（=具体イベント決定後）のみ。
+
+確定値:
+- 予約サイト本番 URL: `https://high-q-reservation.onrender.com`（PR Preview も同じ本番値を参照）
+- LINE オープンチャット URL: `https://line.me/ti/g2/f6YscOz1mh7dnUWX_T4fG3mlqzppz7EoC6-k9A?utm_source=invitation&utm_medium=link_copy&utm_campaign=default`
+- LINE オープンチャット名: `社会人バレーボールサークル High Q`
+- X URL: `https://x.com/HighQ_volleybal`
+- X ハンドル: `@HighQ_volleybal`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Hero / Final 両 CTA が event-list 経由になり、「予約サイト直行 → イベント 0 件」を構造的に避ける
+- Hero と Final が上下対称の役割（入口で見せる / 終端で繋がる）になる
+- 予約サイトへの遷移は EventList カードまたは next-session-strip（=具体イベント決定後）のみ
+- LINE / X の URL がプレースホルダではなく本物に置き換わる
+- アンカー・法務リンクが切れていないことを確認する
+- E2E で CTA の遷移先が守られる
+
+**Non-Goals:**
+- 予約サイトのデザイン変更
+- LP 全体のリデザイン（既に #160 系で完了）
+- 予約サイト URL を環境変数経由から脱却すること（PR Preview と本番が同じ env を共有する設計は維持）
+- LINE オープンチャット側のオンボーディング文言の整備
+
+## Decisions
+
+### D1: Hero CTA を「イベントを見る」アンカースクロールに変更
+
+**変更内容:**
+- 文言: 「体験参加してみる」→ 「イベントを見る」
+- リンク先: `reservationTopUrl()` → `#event-list-heading` へのスムーススクロール
+- 実装: Button を `<a>` で囲む or `@click` でアンカーへ `scrollIntoView({ behavior: 'smooth' })`
+
+**Why:** Hero でユーザーが押した時点では具体イベントの有無を知らないため、予約サイト直行は危険。LP 内 event-list に送ることで:
+- イベントあり → 「これに行こう」と決めてからイベントカード経由で予約サイトへ（会員登録の動機が明確）
+- イベントなし → event-list の Empty 文言で「次回開催待ち」を理解 + final-cta の LINE 経路に自然に流れる
+
+**Alternative:** 予約サイト直行（本提案前の方針） → イベント 0 件で離脱が発生する構造リスクを残すため不採用。
+
+### D2: Final CTA を「LINE Primary + event-list Secondary」の 2 階層に再構成
+
+**最終形:**
+```
+[ LINE で相談・告知を受け取る ]      ← Primary: ink/paper の強いボタン
+                                       href = LINE_OPEN_CHAT_URL
+                                       target=_blank rel=noopener noreferrer
+                                       data-testid = final-cta-line
+
+  または、まずは                       ← 繋ぎ文言（小さく/控えめ）
+[ 次回イベントを見る ]               ← Secondary: outline 控えめ
+                                       href = #event-list-heading
+                                       data-testid = final-cta-event-list
+```
+
+予約サイト直行ボタン・X DM ボタンは撤去。
+
+**Why:**
+- LP 終端まで読み切ったユーザーは関心が高い。ここで一番価値があるのは「**継続接点を作る**」= LINE オープンチャットでイベント告知を受け取れる関係を作る
+- 予約サイト直行を Final に置くと、event-list で 0 件を見たユーザーの再離脱を招く
+- 「または、まずは次回イベントを見る」は、まだ event-list を見ていない / 改めて確認したいユーザー向けの上スクロール経路。Hero と Final の両端に event-list 動線があることで、どの位置からでも event-list に戻れる
+- X DM 撤去理由: X DM は重複（footer SNS に既出）+ CTA の選択肢を絞ることで CVR を上げる
+
+**Alternative:**
+- A. 予約サイト直行 Primary を維持 → イベント 0 件問題が残る
+- B. event-list へのスクロール Primary + LINE Secondary → LP 終端まで来た高関心層が継続接点（LINE）を持たずに離脱するリスク
+- C. 単一 CTA（LINE のみ） → event-list に戻りたい人を取りこぼす（少数派だが）
+- D（採用）: LINE Primary + event-list Secondary → 高関心層を LINE で捕まえ、未確認層は event-list へ送れる
+
+### D3: Final CTA の lead 文言
+
+現状（撤去）:
+> 予約サイトは現在準備中です。
+> まずは LINE オープンチャットから
+> お気軽にご連絡ください。
+
+新案（採用予定。Apply 中に微調整可）:
+> 月1〜2回、土日祝に開催しています。<br>
+> LINE オープンチャットで次回告知が届きます。<br>
+> 不安があれば、まずは質問だけでも。
+
+ポイント:
+- 「準備中」の旧前提を完全削除
+- LINE オープンチャットの「告知を受け取れる」価値を明示（Primary CTA の動機付け）
+- 「質問だけでも」で初心者ウェルカム感を維持
+
+### D4: next-session-strip の LINE fallback 撤去
+
+現状:
+```js
+const nextHref = computed(() => {
+  if (!nextEvent.value) return null
+  const url = reservationEventUrl(nextEvent.value.id)
+  return url || LINE_OPEN_CHAT_URL
+})
+```
+
+変更後:
+```js
+const nextHref = computed(() => {
+  if (!nextEvent.value) return null
+  return reservationEventUrl(nextEvent.value.id)
+})
+```
+
+**Why:** next-session-strip は「具体的な次回イベント」がある時のみ描画され、そのイベントの予約 URL に飛ぶ役割。ユーザーは具体イベントを認知した上でクリックするため、予約サイト直行で不満は出ない。`VITE_RESERVATION_URL` は本番稼働で常に値を持つため `|| LINE_OPEN_CHAT_URL` fallback は不要。
+
+### D5: SNS 定数の本物化
+
+`apps/lp/src/shared/config/sns.js`:
+```js
+export const LINE_OPEN_CHAT_URL = 'https://line.me/ti/g2/f6YscOz1mh7dnUWX_T4fG3mlqzppz7EoC6-k9A?utm_source=invitation&utm_medium=link_copy&utm_campaign=default'
+export const LINE_OPEN_CHAT_NAME = '社会人バレーボールサークル High Q'
+export const X_URL = 'https://x.com/HighQ_volleybal'
+export const X_HANDLE = '@HighQ_volleybal'
+```
+
+UTM パラメータは LINE オープンチャット招待リンク仕様としてそのまま保持。
+
+### D6: 環境戦略は「ローカル / PR Preview / 本番」の 3 環境のみ
+
+`VITE_RESERVATION_URL` の管理:
+- ローカル: `.env` または `.env.local` で設定（開発者が自分の Render PR Preview 等を指す）
+- PR Preview: Render Dashboard の env var で本番値（`https://high-q-reservation.onrender.com`）を上書き設定。これは memory `project_pr_preview_targets_prd_supabase.md` の方針と整合
+- 本番: 同上の本番値
+- E2E: `playwright.config.ts` 内のモック値（`http://localhost:4175`）を維持
+
+**Why:** dev 専用環境は持たない。PR Preview が本番値を共有することで、リハーサル環境として機能する。コードに URL をハードコードしないことで Phase 移行（独自ドメインへの移行など）への耐性も維持。
+
+### D7: アンカー実在性とスクロールオフセットの検証
+
+site-header / site-footer の 5 アンカー（`#about-heading` / `#features-heading` / `#flow-heading` / `#event-list-heading` / `#faq-heading`）+ 今回追加する Hero CTA / Final CTA Secondary の `#event-list-heading` 参照、すべて該当 widget 内に `id="..."` を持つ要素が実在することを確認する。
+
+検証方法:
+1. grep で各 `id="..."` の存在を確認
+2. ブラウザで実際にクリックしてジャンプ先が見出し直下に来ることを確認
+3. sticky header が見出しを隠していないか目視
+
+sticky header オフセットが必要なら各 `id` 付き見出しに CSS `scroll-margin-top: 80px;`（具体値は header 高さ依存）を付与する（Apply 時の状況次第）。
+
+### D8: スムーススクロールの実装方法
+
+候補:
+- A. CSS `html { scroll-behavior: smooth; }` をグローバルに有効化 → 全アンカーリンクが自動でスムースになる、最小実装
+- B. JS で `document.querySelector('#event-list-heading')?.scrollIntoView({ behavior: 'smooth' })` を click ハンドラ内で実行 → アンカー以外への適用も可能だが、アンカー URL が history に残らない
+
+**採用: A**。global `scroll-behavior: smooth` で十分。既に他のアンカー（site-header メニュー、footer リンク）も滑らかになるメリットあり。global CSS の場所は `apps/lp/src/style.css` or 同等のグローバル CSS に追加。
+
+### D9: E2E カバレッジ
+
+`e2e/lp/cta-links.e2e.ts` に以下を追加:
+
+- Hero CTA が `#event-list-heading` を指す（`href` または `data-target` 検証）
+- Final CTA Primary が `LINE_OPEN_CHAT_URL` 相当を指し、`target=_blank rel=noopener noreferrer` を持つ
+- Final CTA Secondary が `#event-list-heading` を指す
+- Final CTA から X DM ボタン（`data-testid="final-cta-x"`）が存在しない
+- Final CTA から「予約サイトでイベントを見る」相当の予約サイト直行ボタンが存在しない
+- next-session 帯のリンクが `reservationEventUrl(id)` を指す（LINE fallback がないこと）
+
+## Risks / Trade-offs
+
+- **[Risk]** Render 本番 env の `VITE_RESERVATION_URL` が想定と異なる可能性 → **Mitigation**: Apply 時に Render Dashboard を確認するタスクを入れる
+- **[Risk]** LINE / X URL が将来変わると `sns.js` の修正で追従する必要 → **Mitigation**: 環境変数化も検討余地はあるが、SNS URL は頻繁に変わらない前提で当面ハードコード
+- **[Risk]** Final から「予約サイト直行」CTA が消えることで、高関心層が予約サイトに辿り着く動線が遅くなる可能性 → **Mitigation**: event-list の各イベントカードで予約サイトに直行できるため、event-list を経由する 1 ステップ追加に留まる。むしろこの 1 ステップが「具体イベント決定後の会員登録」という健全な動機付けになる
+- **[Trade-off]** `scroll-behavior: smooth` をグローバルに有効化することで、すべてのアンカーリンクがスムースになる。意図しない箇所でスムース挙動を入れたくないケースはないため許容
+
+### D10: EventList カード / next-session-strip は明示「予約する」ボタンを描画する（Apply 中追加）
+
+**背景:** 当初の実装ではカード/帯全体を `<a>` でラップし「カード全体クリッカブル + 小さな矢印」のスタイルだった。翔太郎くんから「予約ボタンが見えない」「特定イベント予約のリンクが分かりにくい」との指摘。
+
+**変更:**
+- EventList カード: 全体ラップの `<a>` を `<article>` に変更し、カード内右側に **明示的な「予約する」ボタン**（ink + pill 形）を配置。`data-testid="event-card-cta-<id>"`
+- next-session-strip: 行全体ラップの `<component :is>` を `<div>` に固定し、行内右側に「予約する」ボタン（accent + pill 形）を配置。`data-testid="next-session-cta"`
+- 「予約 URL が空のカードは予約準備中表示」分岐は撤去。予約サイト商用稼働で `reservationEventUrl(id)` は常に有効 URL を返す前提
+
+**Why:** 視認性の高い明示 CTA が「予約する」という行動を直接表現できる。カード全体クリッカブルは便利だが「予約する」というアクションが視覚化されないため初心者ユーザーには伝わりにくい。
+
+### D11: ローカル dev ポートを LP=5173 / reservation=5174 で固定（Apply 中追加）
+
+**背景:** ローカルで LP の予約ボタンをクリックすると LP 自身にリダイレクトする現象。`VITE_RESERVATION_URL` 未設定が原因だが、ローカル動作確認には reservation の固定 URL が必要。
+
+**変更:**
+- `apps/lp/vite.config.js` に `server: { port: 5173, strictPort: true }` を追加
+- `apps/reservation/vite.config.ts` に `server: { port: 5174, strictPort: true }` を追加
+- ローカル `.env.local`（翔太郎くん管理）に `VITE_RESERVATION_URL=http://localhost:5174` を設定して使う
+
+**Why:** strictPort によりポートが暗黙にズレることがなくなり、`.env.local` の URL 指定が常に安定する。
+
+## Open Questions
+
+- Final CTA lead 文言の最終案は D3 のドラフトをベースに Apply 中の見た目で微調整
+- sticky header の高さに応じた `scroll-margin-top` の具体値は Apply 中の目視で確定

--- a/openspec/changes/archive/2026-05-14-lp-cta-reservation-first/proposal.md
+++ b/openspec/changes/archive/2026-05-14-lp-cta-reservation-first/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+予約サイト・admin が MVP1 完了し商用稼働した一方、LP の CTA は「予約サイトは現在準備中」前提のまま LINE を主動線にしている。`release/lp-redesign-v2` を master に出して LP 商用公開する前に CTA 動線を刷新する。
+
+ただし「予約サイトに直行 → イベント 0 件 → 会員登録だけして終わる」体験は最悪なので、**LP 内の event-list を必ず経由する** 設計とする。Hero は「イベントを見る → event-list へスクロール」、Final CTA は「LINE で継続接点を作る + 副でイベント一覧へ」の **上下対称** な構成にし、予約サイトへの直接遷移は event-list の各イベントカード経由のみとする。
+
+## What Changes
+
+- **Hero CTA**: 「体験参加してみる」を「**イベントを見る**」に文言変更し、リンク先を `reservationTopUrl()` から **`#event-list-heading` へのスムーススクロール** に変更
+- **Final CTA**: Primary を「**LINE で相談・告知を受け取る**」（LINE オープンチャット）、Secondary を「**次回イベントを見る**」（`#event-list-heading` スクロール）の 2 層構造に再構成。予約サイト直行ボタンと X DM ボタンは撤去
+- **Final CTA lead 文言**: 「予約サイトは現在準備中…」を撤去し、event-list で具体イベントを見つけてから予約・継続接点として LINE を使う流れを示唆する文言に書き換え
+- **next-session-strip**: 個別イベント決定後の遷移なので予約サイト直行 (`reservationEventUrl(id)`) のままで OK。`|| LINE_OPEN_CHAT_URL` の fallback は撤去
+- **SNS 定数の本物化**: `apps/lp/src/shared/config/sns.js` の LINE / X URL を翔太郎くん共有の本物値に更新
+- **`VITE_RESERVATION_URL` の本番値検証**: Render 本番 env が `https://high-q-reservation.onrender.com` を指していることを確認（PR Preview も同じ本番値を共有）
+- **アンカー実在性と法務リンクの最終確認**: site-header / site-footer の 5 アンカー、`/privacy`、`/external-transmission`、mailto contactEmail を点検
+- **E2E に CTA リンク検証を追加**: Hero と Final の Primary/Secondary が想定先を指すこと
+
+## Capabilities
+
+### New Capabilities
+- なし
+
+### Modified Capabilities
+- `lp-layout`: Hero CTA / Final CTA / next-session-strip の遷移先と階層構造を、event-list を経由する設計に変更
+
+## Impact
+
+- 修正: `apps/lp/src/widgets/hero-first/ui/HeroFirst.vue`（文言変更 + アンカースクロール化）
+- 修正: `apps/lp/src/widgets/final-cta/ui/FinalCtaSection.vue`（lead 文言・CTA 構造の全面刷新）
+- 修正: `apps/lp/src/widgets/next-session-strip/ui/NextSessionStrip.vue`（LINE fallback 撤去）
+- 修正: `apps/lp/src/shared/config/sns.js`（LINE / X URL を本物化）
+- 検証: Render 本番 env の `VITE_RESERVATION_URL` 値
+- 検証: site-header / site-footer のアンカー実在性、`/privacy`・`/external-transmission`・mailto の動作
+- E2E 追加: `e2e/lp/cta-links.e2e.ts`
+- 環境: ローカル / PR Preview / 本番 の 3 環境のみ存在（dev 専用環境は持たない）

--- a/openspec/changes/archive/2026-05-14-lp-cta-reservation-first/specs/lp-layout/spec.md
+++ b/openspec/changes/archive/2026-05-14-lp-cta-reservation-first/specs/lp-layout/spec.md
@@ -1,0 +1,88 @@
+## MODIFIED Requirements
+
+### Requirement: Hero セクションに CTA ボタンが2つ表示される
+
+Hero セクションには、訪問者を **LP 内のイベント一覧** に誘導する主要 CTA ボタンが 1 つ表示されなければならない（SHALL）。CTA をクリックすると `#event-list-heading` へスムーススクロールし、現在開催予定のイベントを確認できる。予約サイト (`reservationTopUrl()`) への直接遷移は Hero CTA からは行わず、event-list の各イベントカードまたは next-session-strip 経由でのみ可能とする。
+
+#### Scenario: Hero CTA の表示
+
+- **WHEN** ユーザーが LP を開いて Hero セクションを見たとき
+- **THEN** 「イベントを見る」ボタン（Primary variant）が 1 つ Hero 内に表示される
+
+#### Scenario: Hero CTA クリック時の挙動
+
+- **WHEN** ユーザーが「イベントを見る」ボタンをクリックしたとき
+- **THEN** ページが `#event-list-heading` へスムーススクロールする。`window.location.href` による外部サイト遷移は発生しない
+
+## ADDED Requirements
+
+### Requirement: Final CTA セクションは LINE 主・event-list 副の 2 階層構造を持つ
+
+LP 最下部の final-cta widget は、Primary（LINE オープンチャットでの継続接点）と Secondary（event-list へのスクロール）の 2 つの CTA を視覚的階層を明確に分けた状態で表示しなければならない（SHALL）。予約サイト直行ボタン・X DM ボタンは含めない（予約サイトへの遷移は event-list 経由のみ、X フォローは footer SNS リンクに集約）。lead 文言は「予約サイトは現在準備中」前提の旧文言を含まず、LINE オープンチャットでイベント告知を受け取れる継続接点としての価値が伝わる文言でなければならない。
+
+#### Scenario: Primary CTA が LINE オープンチャットを指す
+
+- **WHEN** ユーザーが final-cta セクションの Primary ボタンをクリックする
+- **THEN** `LINE_OPEN_CHAT_URL` に `target="_blank" rel="noopener noreferrer"` で新規タブ遷移する。ボタンには `data-testid="final-cta-line"` が付与され、ink/paper の強いボタンスタイルで表示される
+
+#### Scenario: Secondary CTA が event-list へスクロールする
+
+- **WHEN** ユーザーが final-cta セクションの Secondary ボタンをクリックする
+- **THEN** ページが `#event-list-heading` へスムーススクロールする。ボタンには `data-testid="final-cta-event-list"` が付与され、outline 系の控えめなスタイルで Primary より視覚的に弱い
+
+#### Scenario: 予約サイト直行ボタンが final-cta に存在しない
+
+- **WHEN** ユーザーが final-cta セクションを表示する
+- **THEN** `reservationTopUrl()` を直接 href に持つボタン（予約サイト直行）は描画されない（予約サイトへの遷移は event-list の各イベントカード経由のみ）
+
+#### Scenario: X DM ボタンが final-cta に存在しない
+
+- **WHEN** ユーザーが final-cta セクションを表示する
+- **THEN** X ハンドルを直接示す DM 用ボタンは描画されない（footer の SNS リンクで X フォロー導線は別途維持）
+
+#### Scenario: lead 文言が LINE 継続接点を示唆する
+
+- **WHEN** ユーザーが final-cta セクションを表示する
+- **THEN** lead テキストに「予約サイトは現在準備中」「準備中です」等の旧フェーズ前提の文言が含まれず、LINE オープンチャットで告知を受け取れる旨が含まれる
+
+### Requirement: next-session-strip は予約 URL に直接遷移する
+
+LP の next-session-strip widget は、次回イベントの予約 URL (`reservationEventUrl(id)`) に直接遷移しなければならない（SHALL）。予約 URL が空文字の場合に LINE オープンチャットへフォールバックする旧挙動は持たない。
+
+#### Scenario: 次回イベントが存在する場合
+
+- **WHEN** API から次回イベントが取得され、`nextEvent.value` に値が入っている
+- **THEN** strip 全体が `reservationEventUrl(nextEvent.value.id)` を指すリンクとして描画される
+
+#### Scenario: 予約 URL fallback の LINE 遷移が発生しない
+
+- **WHEN** next-session-strip がレンダリングされる
+- **THEN** `reservationEventUrl()` が空文字を返すケースを `LINE_OPEN_CHAT_URL` で補う `||` 演算子の fallback は存在しない（コードレベルで撤去されている）
+
+### Requirement: LP の SNS 定数は本物の URL を保持する
+
+LP の `apps/lp/src/shared/config/sns.js` で定義される SNS 定数は、ダミーまたはプレースホルダではなく、HQ の本物の SNS アカウントに繋がる URL を保持しなければならない（SHALL）。
+
+#### Scenario: LINE オープンチャット URL が本物を指す
+
+- **WHEN** 開発者が `apps/lp/src/shared/config/sns.js` の `LINE_OPEN_CHAT_URL` を参照する
+- **THEN** その値は `https://line.me/ti/g2/f6YscOz1mh7dnUWX_T4fG3mlqzppz7EoC6-k9A` で始まる本物のオープンチャット招待 URL である（UTM パラメータは保持）
+
+#### Scenario: X アカウント URL とハンドルが本物を指す
+
+- **WHEN** 開発者が `apps/lp/src/shared/config/sns.js` の `X_URL` / `X_HANDLE` を参照する
+- **THEN** `X_URL` は `https://x.com/HighQ_volleybal` であり、`X_HANDLE` は `@HighQ_volleybal` である
+
+### Requirement: LP は全アンカー遷移でスムーススクロールを提供する
+
+LP は、Hero CTA / Final CTA Secondary / site-header メニュー / site-footer アンカーなど、全アンカーリンクのクリックでスムーススクロールを提供しなければならない（SHALL）。実装はグローバル CSS `html { scroll-behavior: smooth; }` で行い、個別 JS ハンドラには依存しない。
+
+#### Scenario: グローバル CSS にスムーススクロールが定義されている
+
+- **WHEN** 開発者が LP のグローバル CSS を参照する
+- **THEN** `html { scroll-behavior: smooth; }` が定義されている
+
+#### Scenario: アンカーリンククリックでスムーススクロールする
+
+- **WHEN** ユーザーが LP 内のアンカーリンク（例: `#event-list-heading`）をクリックする
+- **THEN** ページが即座にジャンプせず、滑らかにスクロールしてアンカー先に到達する

--- a/openspec/changes/archive/2026-05-14-lp-cta-reservation-first/tasks.md
+++ b/openspec/changes/archive/2026-05-14-lp-cta-reservation-first/tasks.md
@@ -1,0 +1,61 @@
+## 1. SNS 定数の本物化
+
+- [x] 1.1 `apps/lp/src/shared/config/sns.js` の `LINE_OPEN_CHAT_URL` を `https://line.me/ti/g2/f6YscOz1mh7dnUWX_T4fG3mlqzppz7EoC6-k9A?utm_source=invitation&utm_medium=link_copy&utm_campaign=default` に更新
+- [x] 1.2 同ファイルに `LINE_OPEN_CHAT_NAME = '社会人バレーボールサークル High Q'` を追加
+- [x] 1.3 `X_URL` を `https://x.com/HighQ_volleybal`、`X_HANDLE` を `@HighQ_volleybal` に更新
+
+## 2. グローバルスムーススクロール
+
+- [x] 2.1 LP のグローバル CSS（`apps/lp/src/style.css` または `apps/lp/src/main.js` で import 済みの CSS ファイル）に `html { scroll-behavior: smooth; }` を追加
+- [x] 2.2 各 `id="..."` 付き見出し（`#about-heading` / `#features-heading` / `#flow-heading` / `#event-list-heading` / `#faq-heading`）に `scroll-margin-top: 80px;` 相当を付与（sticky header の高さに合わせ Apply 中に調整）
+
+## 3. Hero CTA を event-list スクロールに変更
+
+- [x] 3.1 `apps/lp/src/widgets/hero-first/ui/HeroFirst.vue` の `<Button>` を `<a href="#event-list-heading">` でラップする、または `@click` でアンカー遷移する形に変更（最終形は Apply 中に決定）
+- [x] 3.2 文言「体験参加してみる」を「**イベントを見る**」に変更
+- [x] 3.3 `onTrialClick` 関数および `reservationTopUrl` の import を不要なら削除
+- [x] 3.4 hero CTA に `data-testid="hero-event-list-cta"` を付与
+
+## 4. Final CTA の構造刷新
+
+- [x] 4.1 `apps/lp/src/widgets/final-cta/ui/FinalCtaSection.vue` の lead 文言を design.md D3 の新案に書き換え（Apply 中に最終微調整可）:
+       > 月1〜2回、土日祝に開催しています。<br>
+       > LINE オープンチャットで次回告知が届きます。<br>
+       > 不安があれば、まずは質問だけでも。
+- [x] 4.2 Primary CTA を「**LINE で相談・告知を受け取る**」に変更し、`href=LINE_OPEN_CHAT_URL` `target=_blank rel=noopener noreferrer` を維持。ink/paper の強いボタンスタイル、`data-testid="final-cta-line"`
+- [x] 4.3 Secondary CTA を「**次回イベントを見る**」に変更し、`href="#event-list-heading"` でアンカー遷移。outline 系の控えめスタイル、`data-testid="final-cta-event-list"`
+- [x] 4.4 Primary と Secondary の間に「または、まずは」相当の繋ぎ文言を入れる（小さい文字、控えめ）
+- [x] 4.5 X DM ボタン（旧 `final-cta-x`）を削除し、関連 CSS を整理。`import` から `X_URL` / `X_HANDLE` を削除
+- [x] 4.6 予約サイト直行ボタンを設置しない（既存にあれば削除）。`reservationTopUrl` import を不要なら削除
+
+## 5. next-session-strip の LINE fallback 撤去
+
+- [x] 5.1 `apps/lp/src/widgets/next-session-strip/ui/NextSessionStrip.vue` の `nextHref` computed から `|| LINE_OPEN_CHAT_URL` を撤去
+- [x] 5.2 不要になった `import { LINE_OPEN_CHAT_URL }` を削除
+- [x] 5.3 「次回イベントなし」表示が現状維持で問題ないことを目視確認
+
+## 6. 環境変数 / アンカー / 法務の最終確認
+
+- [x] 6.1 Render Dashboard 本番 service の `VITE_RESERVATION_URL` が `https://high-q-reservation.onrender.com` を指していることを翔太郎くんと確認
+- [x] 6.2 PR Preview が本番 `VITE_RESERVATION_URL` を sync:false で参照していることを確認（memory `project_pr_preview_targets_prd_supabase.md` 方針と整合）
+- [x] 6.3 site-header / site-footer のアンカー 5 件（`#about-heading` / `#features-heading` / `#flow-heading` / `#event-list-heading` / `#faq-heading`）が `apps/lp/src/widgets/*` 内に対応する `id="..."` を持つ要素として実在することを `grep` で検証
+- [x] 6.4 `/privacy` / `/external-transmission` への遷移が正常に動作することを確認
+- [x] 6.5 privacy / external-transmission ページ内の mailto contactEmail の値が実在アドレスかを翔太郎くんに確認
+
+## 7. E2E カバレッジ追加
+
+- [x] 7.1 `e2e/lp/cta-links.e2e.ts` を新規作成
+- [x] 7.2 「Hero CTA が `#event-list-heading` を指す」テストを追加（`data-testid="hero-event-list-cta"` の `href` 属性 or アンカー遷移を assert）
+- [x] 7.3 「Final CTA primary が `LINE_OPEN_CHAT_URL` を指し target=_blank である」テストを追加（`data-testid="final-cta-line"` 検証）
+- [x] 7.4 「Final CTA secondary が `#event-list-heading` を指す」テストを追加（`data-testid="final-cta-event-list"` 検証）
+- [x] 7.5 「Final CTA から X DM ボタンが消えている」テストを追加（`data-testid="final-cta-x"` が存在しないことを assert）
+- [x] 7.6 「Final CTA から予約サイト直行ボタンが消えている」テストを追加（`reservationTopUrl()` を直接 href に持つボタンが Final 内に無いことを検証）
+- [x] 7.7 「next-session 帯のリンクが `reservationEventUrl(id)` を指す」テストを追加（LINE fallback が発生しないことの確認）
+
+## 8. 検証
+
+- [x] 8.1 `pnpm --filter @high-q/lp build` 成功
+- [x] 8.2 `pnpm --filter @high-q/lp test` 成功（既存 unit test に regression がないこと）
+- [x] 8.3 `pnpm exec playwright test e2e/lp` 全 pass（既存 3 件 + 新規 6 件）
+- [x] 8.4 `pnpm --filter @high-q/lp dev` を立ち上げ、420 / 768 / 1280px の 3 幅で Hero / Final CTA の見た目を目視確認
+- [x] 8.5 各 CTA を実際にクリックして遷移先が想定通りであること（Hero → event-list / Final Primary → LINE / Final Secondary → event-list / next-session → 予約サイト）を確認

--- a/openspec/specs/lp-layout/spec.md
+++ b/openspec/specs/lp-layout/spec.md
@@ -5,19 +5,17 @@ LP (apps/lp) の主要セクション・ヘッダー・フッター・ナビゲ�
 ## Requirements
 ### Requirement: Hero セクションに CTA ボタンが2つ表示される
 
-Hero セクションには、訪問者を主要アクションに誘導する CTA ボタンが2つ表示されなければならない（SHALL）。1つ目は X (Twitter) でのお問い合わせ、2つ目は EVENT セクションへのアンカーリンク。
+Hero セクションには、訪問者を **LP 内のイベント一覧** に誘導する主要 CTA ボタンが 1 つ表示されなければならない（SHALL）。CTA をクリックすると `#event-list-heading` へスムーススクロールし、現在開催予定のイベントを確認できる。予約サイト (`reservationTopUrl()`) への直接遷移は Hero CTA からは行わず、event-list の各イベントカードまたは next-session-strip 経由でのみ可能とする。
 
 #### Scenario: Hero CTA の表示
+
 - **WHEN** ユーザーが LP を開いて Hero セクションを見たとき
-- **THEN** 「X でお問い合わせ」ボタンと「イベントを見る」ボタンの2つが Hero 内に表示される
+- **THEN** 「イベントを見る」ボタン（Primary variant）が 1 つ Hero 内に表示される
 
-#### Scenario: X CTA クリック時の挙動
-- **WHEN** ユーザーが「X でお問い合わせ」ボタンをクリックしたとき
-- **THEN** `https://twitter.com/c8w5y` が新規タブで開かれる
+#### Scenario: Hero CTA クリック時の挙動
 
-#### Scenario: イベント CTA クリック時の挙動
 - **WHEN** ユーザーが「イベントを見る」ボタンをクリックしたとき
-- **THEN** ページが EVENT セクション（`#event` アンカー）にスクロールする
+- **THEN** ページが `#event-list-heading` へスムーススクロールする。`window.location.href` による外部サイト遷移は発生しない
 
 ### Requirement: ヘッダーにアンカーナビゲーションが表示される
 
@@ -241,4 +239,75 @@ LP の gallery-sns widget（heading 領域）は、Instagram 連携実装前の�
 
 - **WHEN** LP の Gallery & Social セクションを開く
 - **THEN** X など既存の SNS リンクボタンは引き続き描画され、`target="_blank" rel="noopener noreferrer"` 属性を維持する
+
+### Requirement: Final CTA セクションは LINE 主・event-list 副の 2 階層構造を持つ
+
+LP 最下部の final-cta widget は、Primary（LINE オープンチャットでの継続接点）と Secondary（event-list へのスクロール）の 2 つの CTA を視覚的階層を明確に分けた状態で表示しなければならない（SHALL）。予約サイト直行ボタン・X DM ボタンは含めない（予約サイトへの遷移は event-list 経由のみ、X フォローは footer SNS リンクに集約）。lead 文言は「予約サイトは現在準備中」前提の旧文言を含まず、LINE オープンチャットでイベント告知を受け取れる継続接点としての価値が伝わる文言でなければならない。
+
+#### Scenario: Primary CTA が LINE オープンチャットを指す
+
+- **WHEN** ユーザーが final-cta セクションの Primary ボタンをクリックする
+- **THEN** `LINE_OPEN_CHAT_URL` に `target="_blank" rel="noopener noreferrer"` で新規タブ遷移する。ボタンには `data-testid="final-cta-line"` が付与され、ink/paper の強いボタンスタイルで表示される
+
+#### Scenario: Secondary CTA が event-list へスクロールする
+
+- **WHEN** ユーザーが final-cta セクションの Secondary ボタンをクリックする
+- **THEN** ページが `#event-list-heading` へスムーススクロールする。ボタンには `data-testid="final-cta-event-list"` が付与され、outline 系の控えめなスタイルで Primary より視覚的に弱い
+
+#### Scenario: 予約サイト直行ボタンが final-cta に存在しない
+
+- **WHEN** ユーザーが final-cta セクションを表示する
+- **THEN** `reservationTopUrl()` を直接 href に持つボタン（予約サイト直行）は描画されない（予約サイトへの遷移は event-list の各イベントカード経由のみ）
+
+#### Scenario: X DM ボタンが final-cta に存在しない
+
+- **WHEN** ユーザーが final-cta セクションを表示する
+- **THEN** X ハンドルを直接示す DM 用ボタンは描画されない（footer の SNS リンクで X フォロー導線は別途維持）
+
+#### Scenario: lead 文言が LINE 継続接点を示唆する
+
+- **WHEN** ユーザーが final-cta セクションを表示する
+- **THEN** lead テキストに「予約サイトは現在準備中」「準備中です」等の旧フェーズ前提の文言が含まれず、LINE オープンチャットで告知を受け取れる旨が含まれる
+
+### Requirement: next-session-strip は予約 URL に直接遷移する
+
+LP の next-session-strip widget は、次回イベントの予約 URL (`reservationEventUrl(id)`) に直接遷移しなければならない（SHALL）。予約 URL が空文字の場合に LINE オープンチャットへフォールバックする旧挙動は持たない。
+
+#### Scenario: 次回イベントが存在する場合
+
+- **WHEN** API から次回イベントが取得され、`nextEvent.value` に値が入っている
+- **THEN** strip 全体が `reservationEventUrl(nextEvent.value.id)` を指すリンクとして描画される
+
+#### Scenario: 予約 URL fallback の LINE 遷移が発生しない
+
+- **WHEN** next-session-strip がレンダリングされる
+- **THEN** `reservationEventUrl()` が空文字を返すケースを `LINE_OPEN_CHAT_URL` で補う `||` 演算子の fallback は存在しない（コードレベルで撤去されている）
+
+### Requirement: LP の SNS 定数は本物の URL を保持する
+
+LP の `apps/lp/src/shared/config/sns.js` で定義される SNS 定数は、ダミーまたはプレースホルダではなく、HQ の本物の SNS アカウントに繋がる URL を保持しなければならない（SHALL）。
+
+#### Scenario: LINE オープンチャット URL が本物を指す
+
+- **WHEN** 開発者が `apps/lp/src/shared/config/sns.js` の `LINE_OPEN_CHAT_URL` を参照する
+- **THEN** その値は `https://line.me/ti/g2/f6YscOz1mh7dnUWX_T4fG3mlqzppz7EoC6-k9A` で始まる本物のオープンチャット招待 URL である（UTM パラメータは保持）
+
+#### Scenario: X アカウント URL とハンドルが本物を指す
+
+- **WHEN** 開発者が `apps/lp/src/shared/config/sns.js` の `X_URL` / `X_HANDLE` を参照する
+- **THEN** `X_URL` は `https://x.com/HighQ_volleybal` であり、`X_HANDLE` は `@HighQ_volleybal` である
+
+### Requirement: LP は全アンカー遷移でスムーススクロールを提供する
+
+LP は、Hero CTA / Final CTA Secondary / site-header メニュー / site-footer アンカーなど、全アンカーリンクのクリックでスムーススクロールを提供しなければならない（SHALL）。実装はグローバル CSS `html { scroll-behavior: smooth; }` で行い、個別 JS ハンドラには依存しない。
+
+#### Scenario: グローバル CSS にスムーススクロールが定義されている
+
+- **WHEN** 開発者が LP のグローバル CSS を参照する
+- **THEN** `html { scroll-behavior: smooth; }` が定義されている
+
+#### Scenario: アンカーリンククリックでスムーススクロールする
+
+- **WHEN** ユーザーが LP 内のアンカーリンク（例: `#event-list-heading`）をクリックする
+- **THEN** ページが即座にジャンプせず、滑らかにスクロールしてアンカー先に到達する
 


### PR DESCRIPTION
## Summary

LP の CTA 動線を「予約サイト商用稼働前提」に全面刷新。「予約サイト直行 → イベント 0 件 → 不満」を構造的に避けるため、**Hero / Final 両 CTA は LP 内 event-list を経由** し、予約サイトへの遷移は EventList カードと next-session-strip（=具体イベント決定後）のみとする。

## 主な変更

| 位置 | 変更 |
|---|---|
| Hero CTA | 「イベントを見る」→ `#event-list-heading` スクロール（予約サイト直行撤去） |
| Final CTA Primary | 「LINE で相談・告知を受け取る」→ LINE オープンチャット（新規タブ） |
| Final CTA Secondary | 「次回イベントを見る」→ `#event-list-heading` スクロール |
| Final CTA（撤去） | X DM ボタン / 予約サイト直行ボタン |
| Final CTA lead | 「予約サイトは現在準備中」→ 商用稼働前提の文言に書き換え |
| next-session-strip | 行内に明示「予約する」ボタン、`reservationEventUrl(id)` 直行、LINE fallback 撤去 |
| EventList カード | カード内に明示「予約する」ボタン、URL 空判定の disabled 分岐撤去 |
| SNS 定数 | LINE / X URL を翔太郎くん共有の本物に更新、`LINE_OPEN_CHAT_NAME` 追加 |
| グローバル CSS | `html { scroll-behavior: smooth }` + 主要 anchor に `scroll-margin-top: 80px` |
| dev port 固定 | LP=5173 strictPort / reservation=5174 strictPort |

## 検証

- [x] `pnpm --filter @high-q/lp build` 成功
- [x] `pnpm --filter @high-q/reservation build` 成功
- [x] LP E2E **8/8 pass**（既存 3 + 新規 `cta-links.e2e.ts` 5 件）
- [x] LP unit test 38/38 pass
- [x] アンカー 5 件（about/features/flow/event-list/faq）実在確認
- [x] contactEmail（high.q.volleyball@gmail.com）実在確認
- [ ] Render Dashboard 本番 service の `VITE_RESERVATION_URL` が `https://high-q-reservation.onrender.com` を指していることを最終確認

## ローカル動作確認の前提

`.env.local`（モノレポルート）に追記:
```
VITE_RESERVATION_URL=http://localhost:5174
```

その後:
```
pnpm --filter @high-q/reservation dev   # → http://localhost:5174
pnpm --filter @high-q/lp dev            # → http://localhost:5173
```

## OpenSpec

- 新規 change `lp-cta-reservation-first` を `archive/2026-05-14-lp-cta-reservation-first/` に格納
- `lp-layout`: Hero CTA を MODIFIED + Final CTA / next-session / SNS / smooth scroll を ADDED（計 +4, ~1）

## マージ先

`release/lp-redesign-v2`（統合ブランチ）。**本変更で release ブランチが完成** し、release → master の最終 PR 準備が整います。

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)
