### PR TITLE
feat(lp): #245 ハンバーガーメニューを Drawer 化（プロトタイプ準拠）

### DIFF
--- a/apps/lp/src/App.vue
+++ b/apps/lp/src/App.vue
@@ -65,6 +65,10 @@ html {
   scroll-behavior: smooth;
 }
 
+body.is-locked {
+  overflow: hidden;
+}
+
 /* sticky header 分のオフセットで、アンカー遷移時に見出しが隠れないようにする */
 [id="about-heading"],
 [id="features-heading"],

--- a/apps/lp/src/widgets/site-header/ui/SiteHeader.vue
+++ b/apps/lp/src/widgets/site-header/ui/SiteHeader.vue
@@ -17,58 +17,103 @@
         ref="hamburgerEl"
         type="button"
         class="site-header__hamburger"
+        :class="{ 'site-header__hamburger--open': menuOpen }"
         :aria-label="menuOpen ? 'メニューを閉じる' : 'メニューを開く'"
         :aria-expanded="menuOpen ? 'true' : 'false'"
-        aria-controls="site-header-menu"
+        :aria-controls="DRAWER_ID"
         @click="toggleMenu"
       >
-        <span class="site-header__hamburger-bar" />
-        <span class="site-header__hamburger-bar" />
+        <span class="site-header__hamburger-icon" aria-hidden="true">
+          <span class="site-header__hamburger-bar site-header__hamburger-bar--top" />
+          <span class="site-header__hamburger-bar site-header__hamburger-bar--bottom" />
+        </span>
       </button>
     </div>
 
-    <Transition name="site-header-menu">
+    <Teleport to="body">
       <nav
-        v-if="menuOpen"
-        id="site-header-menu"
-        ref="menuEl"
-        class="site-header__menu"
-        role="navigation"
-        aria-label="サイト内ナビゲーション"
+        :id="DRAWER_ID"
+        ref="drawerEl"
+        class="site-drawer"
+        :class="{ 'site-drawer--open': menuOpen }"
+        :aria-hidden="menuOpen ? 'false' : 'true'"
+        aria-label="サイトメニュー"
+        tabindex="-1"
       >
-        <a
-          v-for="link in links"
-          :key="link.href"
-          :href="link.href"
-          class="site-header__menu-link"
-          @click="closeMenu"
-        >
-          {{ link.label }}
-        </a>
+        <div class="site-drawer__inner">
+          <div class="site-drawer__kicker">Menu</div>
+          <div class="site-drawer__nav">
+            <a
+              v-for="(link, idx) in links"
+              :key="link.href"
+              ref="drawerLinkEls"
+              :href="link.href"
+              class="site-drawer__link"
+              @click="onLinkClick"
+            >
+              <span class="site-drawer__link-num">{{ formatNum(idx + 1) }}</span>
+              <span class="site-drawer__link-label">{{ link.label }}</span>
+              <span class="site-drawer__link-arrow" aria-hidden="true">›</span>
+            </a>
+          </div>
+        </div>
+
+        <div class="site-drawer__footer">
+          <a
+            class="site-drawer__cta-primary"
+            :href="LINE_OPEN_CHAT_URL"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="drawer-cta-line"
+            @click="closeMenu"
+          >
+            LINE オープンチャットで連絡
+          </a>
+          <a
+            class="site-drawer__cta-secondary"
+            href="#event-list-heading"
+            data-testid="drawer-cta-event-list"
+            @click="onLinkClick"
+          >
+            イベント一覧を見る
+          </a>
+          <div class="site-drawer__meta">
+            <span>Tokyo · Koto-ku</span>
+            <span>© 2026 High Q</span>
+          </div>
+        </div>
       </nav>
-    </Transition>
+    </Teleport>
   </header>
 </template>
 
 <script setup>
-import { ref, onMounted, onBeforeUnmount, nextTick } from 'vue'
+import { ref, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
+import { LINE_OPEN_CHAT_URL } from '@shared/config/sns'
 
 defineProps({
   transparent: { type: Boolean, default: false },
 })
 
+const DRAWER_ID = 'site-drawer'
+
 const scrolled = ref(false)
 const menuOpen = ref(false)
 const hamburgerEl = ref(null)
-const menuEl = ref(null)
+const drawerEl = ref(null)
+const drawerLinkEls = ref([])
 
 const links = [
-  { href: '#about-heading', label: 'About' },
-  { href: '#features-heading', label: 'Features' },
+  { href: '#about-heading', label: 'はじめての方へ' },
+  { href: '#features-heading', label: 'High Q について' },
   { href: '#flow-heading', label: '当日の流れ' },
-  { href: '#event-list-heading', label: 'Events' },
-  { href: '#faq-heading', label: 'FAQ' },
+  { href: '#event-list-heading', label: '開催スケジュール' },
+  { href: '#faq-heading', label: 'よくある質問' },
 ]
+
+function formatNum(n) {
+  return String(n).padStart(2, '0')
+}
 
 function onScroll() {
   if (typeof window === 'undefined') return
@@ -83,23 +128,30 @@ function closeMenu() {
   menuOpen.value = false
 }
 
+function onLinkClick() {
+  setTimeout(closeMenu, 80)
+}
+
 function onKeyDown(event) {
   if (event.key === 'Escape' && menuOpen.value) {
     closeMenu()
+    hamburgerEl.value?.focus()
   }
 }
 
-function onOutsideClick(event) {
-  if (!menuOpen.value) return
-  const target = event.target
-  if (
-    hamburgerEl.value && hamburgerEl.value.contains(target)
-  ) return
-  if (
-    menuEl.value && menuEl.value.contains(target)
-  ) return
-  closeMenu()
-}
+watch(menuOpen, async (open) => {
+  if (typeof document === 'undefined') return
+  document.body.classList.toggle('is-locked', open)
+  if (open) {
+    await nextTick()
+    const first = drawerLinkEls.value?.[0]
+    if (first && typeof first.focus === 'function') {
+      setTimeout(() => first.focus(), 220)
+    }
+  } else {
+    hamburgerEl.value?.focus()
+  }
+})
 
 onMounted(async () => {
   if (typeof window === 'undefined') return
@@ -108,14 +160,15 @@ onMounted(async () => {
   onScroll()
   window.addEventListener('scroll', onScroll, { passive: true })
   window.addEventListener('keydown', onKeyDown)
-  window.addEventListener('click', onOutsideClick, true)
 })
 
 onBeforeUnmount(() => {
   if (typeof window === 'undefined') return
   window.removeEventListener('scroll', onScroll)
   window.removeEventListener('keydown', onKeyDown)
-  window.removeEventListener('click', onOutsideClick, true)
+  if (typeof document !== 'undefined') {
+    document.body.classList.remove('is-locked')
+  }
 })
 </script>
 
@@ -124,7 +177,11 @@ onBeforeUnmount(() => {
   z-index: 100;
   font-family: var(--hq-font-jp);
   box-sizing: border-box;
-  transition: background-color 200ms ease-out, color 200ms ease-out, box-shadow 200ms ease-out;
+  transition:
+    background-color 200ms var(--hq-motion-ease),
+    color 200ms var(--hq-motion-ease),
+    box-shadow 200ms var(--hq-motion-ease),
+    border-color 200ms var(--hq-motion-ease);
 }
 
 .site-header__bar {
@@ -193,25 +250,23 @@ onBeforeUnmount(() => {
   opacity: 0.85;
 }
 
+/* Hamburger trigger (2 bars → ✕) */
 .site-header__hamburger {
-  width: 40px;
-  height: 40px;
+  width: 44px;
+  height: 44px;
   padding: 0;
   background: transparent;
   border: none;
   cursor: pointer;
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 5px;
-  border-radius: 50%;
+  display: grid;
+  place-items: center;
   color: inherit;
-  transition: background 150ms ease;
+  border-radius: 50%;
+  transition: background 150ms var(--hq-motion-ease);
 }
 
 .site-header__hamburger:hover {
-  background: rgba(31, 29, 26, 0.06);
+  background: var(--hq-color-hairline-soft);
 }
 
 .site-header--overlay:not(.site-header--scrolled):not(.site-header--menu-open) .site-header__hamburger:hover {
@@ -223,66 +278,231 @@ onBeforeUnmount(() => {
   outline-offset: 2px;
 }
 
-.site-header__hamburger-bar {
-  display: block;
+.site-header__hamburger-icon {
+  position: relative;
   width: 22px;
-  height: 1px;
+  height: 14px;
+  display: block;
+}
+
+.site-header__hamburger-bar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1.5px;
   background: currentColor;
+  transition:
+    transform 220ms var(--hq-motion-ease),
+    top 180ms var(--hq-motion-ease) 80ms,
+    opacity 120ms var(--hq-motion-ease);
+}
+
+.site-header__hamburger-bar--top {
+  top: 2px;
+}
+
+.site-header__hamburger-bar--bottom {
+  top: 10px;
 }
 
 .site-header--overlay:not(.site-header--scrolled):not(.site-header--menu-open) .site-header__hamburger-bar {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
 }
 
-.site-header__menu {
+.site-header__hamburger--open .site-header__hamburger-bar--top {
+  top: 6px;
+  transform: rotate(45deg);
+  transition:
+    top 180ms var(--hq-motion-ease),
+    transform 220ms var(--hq-motion-ease) 100ms;
+}
+
+.site-header__hamburger--open .site-header__hamburger-bar--bottom {
+  top: 6px;
+  transform: rotate(-45deg);
+  transition:
+    top 180ms var(--hq-motion-ease),
+    transform 220ms var(--hq-motion-ease) 100ms;
+}
+
+/* Drawer (Teleport to body) */
+.site-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: var(--hq-color-paper);
+  color: var(--hq-color-ink);
+  display: flex;
+  flex-direction: column;
+  opacity: 0;
+  transform: translateY(8px);
+  pointer-events: none;
+  transition:
+    opacity 200ms var(--hq-motion-ease),
+    transform 280ms var(--hq-motion-ease);
+  font-family: var(--hq-font-jp);
+}
+
+.site-drawer--open {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.site-drawer__inner {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 80px 28px 16px;
+  padding-inline: max(28px, calc((100% - 560px) / 2));
+}
+
+.site-drawer__kicker {
+  font-family: var(--hq-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: var(--hq-color-muted);
+  margin-bottom: 24px;
+  text-transform: uppercase;
+}
+
+.site-drawer__nav {
+  display: grid;
+}
+
+.site-drawer__link {
+  display: grid;
+  grid-template-columns: 36px 1fr auto;
+  align-items: baseline;
+  gap: 14px;
+  padding: 22px 0;
+  border-top: 1px solid var(--hq-color-hairline);
+  text-decoration: none;
+  color: inherit;
+  transition: padding-left 200ms var(--hq-motion-ease);
+}
+
+.site-drawer__link:last-child {
+  border-bottom: 1px solid var(--hq-color-hairline);
+}
+
+.site-drawer__link:hover {
+  padding-left: 4px;
+}
+
+.site-drawer__link:focus-visible {
+  outline: 2px solid var(--hq-color-accent);
+  outline-offset: 4px;
+}
+
+.site-drawer__link-num {
+  font-family: var(--hq-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--hq-color-muted);
+}
+
+.site-drawer__link-label {
+  font-family: var(--hq-font-jp-display);
+  font-size: 24px;
+  font-weight: 400;
+  line-height: 1.35;
+}
+
+.site-drawer__link-arrow {
+  font-family: var(--hq-font-mono);
+  font-size: 14px;
+  color: var(--hq-color-muted);
+  transition:
+    transform 200ms var(--hq-motion-ease),
+    color 200ms var(--hq-motion-ease);
+}
+
+.site-drawer__link:hover .site-drawer__link-arrow {
+  transform: translateX(4px);
+  color: var(--hq-color-ink);
+}
+
+/* Drawer footer */
+.site-drawer__footer {
+  flex: 0 0 auto;
+  padding: 16px 20px calc(20px + env(safe-area-inset-bottom));
   background: var(--hq-color-paper);
   border-top: 1px solid var(--hq-color-hairline);
-  color: var(--hq-color-ink);
-  padding-inline: max(20px, calc((100% - 880px) / 2));
+  display: grid;
+  gap: 10px;
 }
 
-.site-header__menu-link {
-  display: block;
-  padding: 16px 0;
+.site-drawer__cta-primary,
+.site-drawer__cta-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 48px;
+  border-radius: var(--hq-radius-pill);
   font-family: var(--hq-font-jp);
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 500;
-  letter-spacing: 0.04em;
-  color: var(--hq-color-ink);
   text-decoration: none;
-  border-bottom: 1px solid var(--hq-color-hairline-soft);
+  letter-spacing: 0.02em;
+  transition:
+    opacity 150ms var(--hq-motion-ease),
+    background 150ms var(--hq-motion-ease);
 }
 
-.site-header__menu-link:last-child {
-  border-bottom: none;
+.site-drawer__cta-primary {
+  background: var(--hq-color-ink);
+  color: var(--hq-color-paper);
+  border: 1px solid var(--hq-color-ink);
 }
 
-.site-header__menu-link:hover {
-  color: var(--hq-color-accent);
+.site-drawer__cta-primary:hover {
+  opacity: 0.92;
 }
 
-.site-header__menu-link:focus-visible {
+.site-drawer__cta-primary:focus-visible {
   outline: 2px solid var(--hq-color-accent);
-  outline-offset: -4px;
+  outline-offset: 2px;
 }
 
-/* Transition */
-.site-header-menu-enter-active,
-.site-header-menu-leave-active {
-  transition: max-height 200ms ease-out, opacity 200ms ease-out;
-  overflow: hidden;
-  max-height: 400px;
+.site-drawer__cta-secondary {
+  background: transparent;
+  color: var(--hq-color-ink);
+  border: 1px solid var(--hq-color-hairline);
 }
 
-.site-header-menu-enter-from,
-.site-header-menu-leave-to {
-  max-height: 0;
-  opacity: 0;
+.site-drawer__cta-secondary:hover {
+  background: var(--hq-color-paper-warm);
+}
+
+.site-drawer__cta-secondary:focus-visible {
+  outline: 2px solid var(--hq-color-accent);
+  outline-offset: 2px;
+}
+
+.site-drawer__meta {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--hq-color-hairline-soft);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--hq-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: var(--hq-color-muted);
+  text-transform: uppercase;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .site-header-menu-enter-active,
-  .site-header-menu-leave-active {
+  .site-drawer,
+  .site-drawer__link,
+  .site-drawer__link-arrow,
+  .site-drawer__cta-primary,
+  .site-drawer__cta-secondary,
+  .site-header__hamburger-bar,
+  .site-header__hamburger--open .site-header__hamburger-bar--top,
+  .site-header__hamburger--open .site-header__hamburger-bar--bottom {
     transition: none;
   }
 }

--- a/e2e/lp/site-drawer.e2e.ts
+++ b/e2e/lp/site-drawer.e2e.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test'
+import { mockEventApi } from './_helpers/eventApi'
+
+test.describe('LP SiteHeader Drawer', () => {
+  test('ハンバーガー押下で Drawer が開き、ナビリンクで対応セクションへ遷移して閉じる', async ({ page }) => {
+    await mockEventApi(page, [])
+    await page.goto('/')
+
+    const hamburger = page.getByRole('button', { name: 'メニューを開く' })
+    const drawer = page.locator('#site-drawer')
+
+    await expect(hamburger).toBeVisible()
+    await expect(drawer).toHaveAttribute('aria-hidden', 'true')
+
+    await hamburger.click()
+    await expect(drawer).toHaveAttribute('aria-hidden', 'false')
+    await expect(drawer).toHaveClass(/site-drawer--open/)
+    await expect(page.getByRole('button', { name: 'メニューを閉じる' })).toBeVisible()
+
+    // body スクロールロックの確認
+    await expect(page.locator('body')).toHaveClass(/is-locked/)
+
+    // ナビリンク (event-list) を押下 → アンカー遷移 + Drawer 閉鎖
+    await drawer.getByRole('link', { name: /開催スケジュール/ }).click()
+    await expect(drawer).toHaveAttribute('aria-hidden', 'true')
+    await expect(page.locator('body')).not.toHaveClass(/is-locked/)
+    await expect(page).toHaveURL(/#event-list-heading$/)
+  })
+
+  test('Drawer footer の Primary CTA は LINE オープンチャットを target=_blank で開く', async ({ page }) => {
+    await mockEventApi(page, [])
+    await page.goto('/')
+
+    await page.getByRole('button', { name: 'メニューを開く' }).click()
+
+    const lineCta = page.getByTestId('drawer-cta-line')
+    await expect(lineCta).toBeVisible()
+    const href = await lineCta.getAttribute('href')
+    expect(href).toMatch(/^https:\/\/line\.me\/ti\/g2\//)
+    await expect(lineCta).toHaveAttribute('target', '_blank')
+    await expect(lineCta).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  test('Drawer footer の Secondary CTA は #event-list-heading を指す', async ({ page }) => {
+    await mockEventApi(page, [])
+    await page.goto('/')
+
+    await page.getByRole('button', { name: 'メニューを開く' }).click()
+
+    const eventCta = page.getByTestId('drawer-cta-event-list')
+    await expect(eventCta).toBeVisible()
+    await expect(eventCta).toHaveAttribute('href', '#event-list-heading')
+  })
+
+  test('Esc キー押下で Drawer が閉じ、body lock も解除される', async ({ page }) => {
+    await mockEventApi(page, [])
+    await page.goto('/')
+
+    const hamburger = page.getByRole('button', { name: 'メニューを開く' })
+    const drawer = page.locator('#site-drawer')
+
+    await hamburger.click()
+    await expect(drawer).toHaveAttribute('aria-hidden', 'false')
+    await expect(page.locator('body')).toHaveClass(/is-locked/)
+
+    await page.keyboard.press('Escape')
+    await expect(drawer).toHaveAttribute('aria-hidden', 'true')
+    await expect(page.locator('body')).not.toHaveClass(/is-locked/)
+  })
+})

--- a/openspec/changes/archive/2026-05-14-lp-hamburger-drawer-redesign/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-14-lp-hamburger-drawer-redesign/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/archive/2026-05-14-lp-hamburger-drawer-redesign/design.md
+++ b/openspec/changes/archive/2026-05-14-lp-hamburger-drawer-redesign/design.md
@@ -1,0 +1,68 @@
+## Context
+
+LP のヘッダーは `apps/lp/src/widgets/site-header/ui/SiteHeader.vue` 内で、ハンバーガー押下時に `<nav>` がヘッダー直下にインライン展開する単純な構造になっている。一方、`docs/10-デザインサンプル/lp/HighQ Hamburger Drawer.html` プロトタイプでは、フルスクリーン Drawer と sticky CTA フッタを組み合わせたエディトリアル指向のナビゲーションが提示されており、LP 全体の和紙トーン刷新（#160 系）と方向性が一致している。本変更で site-header のメニュー部分のみをこのプロトタイプに揃える。
+
+CTA 戦略は final-cta widget の現行実装と同期する：Primary = LINE オープンチャット（継続接点）、Secondary = `#event-list-heading` へのスクロール。これは `lp-layout` spec の「Final CTA セクションは LINE 主・event-list 副」要件とも整合する。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- ハンバーガー押下時の体験を、現在のインライン展開からフルスクリーン Drawer に置き換え、プロトタイプの意匠（大型タイポ・番号・矢印・sticky CTA フッタ・body lock・ハンバーガーアニメ）を取り込む
+- アクセシビリティを `aria-*` / Esc / フォーカス管理 / `prefers-reduced-motion` まで含めて整備する
+- final-cta の CTA 戦略と Drawer フッタを揃え、ユーザーがどこからでも同じ Primary 動線（LINE）に到達できるようにする
+- `var(--hq-*)` トークンのみで完結させ、マジックナンバーを残さない
+
+**Non-Goals:**
+
+- 画面右下のフローティング LINE FAB の追加（別 Issue で扱う）
+- ナビ項目体系そのものの再設計（既存の About / Features / 当日の流れ / Events / FAQ をそのまま採用）
+- ヘッダー以外（footer / final-cta / hero）の改修
+- デスクトップ向けの横並びメニュー追加（モバイル / 全画面幅で Drawer を採用）
+
+## Decisions
+
+### Decision 1: SiteHeader.vue 内に Drawer を内包し、別 widget に切り出さない
+
+site-header と Drawer は開閉状態・フォーカス管理・スクロールロックを共有する。別 widget に切り出すと props や ref の受け渡しが煩雑になり、可読性が下がる。Drawer 用テンプレート / styles を SiteHeader.vue 内のスコープに保つ。
+
+**Alternatives considered:** `widgets/site-drawer` として分離 → 状態同期のオーバーヘッドが利益を上回らないため却下。
+
+### Decision 2: Drawer は `<Teleport to="body">` で body 直下に出す
+
+ヘッダーの sticky / overlay 配置による stacking context の影響を受けず、`position: fixed; inset: 0` を素直に効かせるため。
+
+**Alternatives considered:** ヘッダーの兄弟要素として配置 → 親の transform / overflow に影響される可能性があるため却下。
+
+### Decision 3: body スクロールロックは `body.classList.add('is-locked')` 方式
+
+プロトタイプ準拠。CSS 側で `body.is-locked { overflow: hidden; }` を定義。Vue 側からは class 操作のみ。タッチデバイスのスクロール伝播対策として `overscroll-behavior: contain` を Drawer 内コンテナに付与。
+
+**Alternatives considered:** スクロール位置を保存して `position: fixed` を切り替える方式 → iOS Safari で不要なジャンプが起きる懸念があり、本ケースでは class 切替で十分。
+
+### Decision 4: フォーカス管理は最小限（focus trap 完全実装はしない）
+
+開放時に最初の Drawer リンクへフォーカスを移し、閉鎖時にハンバーガーへ戻す。Tab キーが Drawer 外へ抜ける可能性は残るが、Drawer 開放中は背後コンテンツが視覚的にも見えないため、現実的なリスクは低い。完全な focus trap ライブラリ導入は本変更ではコスト過剰。
+
+**Alternatives considered:** `focus-trap` パッケージ導入 → 依存追加と LP バンドルサイズへの影響を考慮し見送り。
+
+### Decision 5: アニメーション値はプロトタイプ準拠の `cubic-bezier(.22,.61,.36,1)` を `--hq-motion-ease` トークンとして共用
+
+LP 内で同じイージングが他にも使われていれば同名トークンを再利用。なければ本変更で `--hq-motion-ease` を tokens.css に追加（design-tokens パッケージへの追加が筋）。
+
+**Alternatives considered:** 各コンポーネントでハードコード → マジックナンバー禁止規約に反するため却下。
+
+## Risks / Trade-offs
+
+- **Risk:** body lock 中に Drawer 内 `overflow-y: auto` のスクロール伝播がブラウザによって背面に漏れる → **Mitigation:** Drawer インナーに `overscroll-behavior: contain` を付与
+- **Risk:** Teleport で body 直下に出すため、SSR / hydration 観点で initial render に Drawer DOM が表示される一瞬がある → **Mitigation:** `opacity: 0; pointer-events: none` を初期値とし、`is-open` class でのみ visible に。FOUC は実質発生しない
+- **Risk:** 既存 LP E2E のメニュー開閉セレクタが変わる → **Mitigation:** SiteHeader.vue の data-testid / role を維持し、E2E 側を最小修正
+- **Risk:** focus trap 不完全により a11y 監査で指摘される可能性 → **Mitigation:** 受け入れる。問題化したら追加 Issue で対応
+
+## Migration Plan
+
+不要（UI 内部実装の刷新であり、外部 API・データモデル・URL 構造は変わらない）。
+
+## Open Questions
+
+- なし。Apply 開始時点での未確定事項なし。

--- a/openspec/changes/archive/2026-05-14-lp-hamburger-drawer-redesign/proposal.md
+++ b/openspec/changes/archive/2026-05-14-lp-hamburger-drawer-redesign/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+LP のハンバーガーメニューが、ヘッダー直下にインライン展開する簡素な実装のままで、LP 全体の和紙トーンと刷新後のデザイン言語（大型タイポ・番号付きインデックス・余白の効いたエディトリアル感）から浮いている。プロトタイプ `HighQ Hamburger Drawer.html` の意匠に揃えることで、ナビゲーション体験そのものを LP のブランド表現の一部に格上げする。
+
+## What Changes
+
+- ハンバーガー押下時の挙動を **インライン展開型 → フルスクリーン Drawer 型** に変更
+- Drawer 内のナビゲーションリンクを **大型タイポ + 番号 (01–05) + 末尾矢印** のエディトリアル形式に再構成
+- ハンバーガーアイコンを 2 本線 → ✕ への滑らかなアニメーションに変更
+- Drawer 開放中は **body スクロールを lock** し、Drawer 内コンテンツのみスクロール可能に
+- Drawer 末尾に **sticky な CTA フッタ** を追加（Primary: LINE オープンチャット / Secondary: イベント一覧へスクロール）。final-cta の CTA 戦略と同期
+- アクセシビリティ強化: `aria-hidden` / `aria-expanded` / Esc 閉じる / 開放時に最初のリンクへフォーカス移動 / 閉じた後にトリガーへフォーカスを戻す
+- `prefers-reduced-motion` でアニメーションを無効化
+
+非対応: 画面右下のフローティング LINE FAB は本変更のスコープ外（別 Issue で扱う）。
+
+## Capabilities
+
+### New Capabilities
+
+なし。
+
+### Modified Capabilities
+
+- `lp-layout`: ヘッダーのナビゲーション要件（現行「ドロップダウンメニュー」を「フルスクリーン Drawer」に置き換え、Drawer 固有のアクセシビリティ要件を追加）
+
+## Impact
+
+- **コード**: `apps/lp/src/widgets/site-header/ui/SiteHeader.vue`（Drawer 化に伴う構造刷新）。Drawer を別 widget に切り出すかは Design で判断。
+- **テスト**: LP E2E のヘッダー周辺シナリオ（メニュー開閉・リンク遷移）を Drawer 前提に更新。新規シナリオとして「Esc で閉じる」「body lock」「フォーカス復帰」を追加する可能性あり。
+- **デザイントークン**: 既存の `--hq-*` で完結。新規トークン追加なし（プロトタイプは既存トークンのみで構成済み）。
+- **依存**: 追加なし。
+- **リリース**: `release/lp-redesign-v2` に統合してから master へマージ（既存 LP UI 改変フローを踏襲）。

--- a/openspec/changes/archive/2026-05-14-lp-hamburger-drawer-redesign/specs/lp-layout/spec.md
+++ b/openspec/changes/archive/2026-05-14-lp-hamburger-drawer-redesign/specs/lp-layout/spec.md
@@ -1,0 +1,69 @@
+## MODIFIED Requirements
+
+### Requirement: ヘッダーにアンカーナビゲーションが表示される
+
+ヘッダーにはハンバーガートリガーが常設され、押下するとフルスクリーン Drawer 形式のサイト内ナビゲーションが表示されなければならない（SHALL）。Drawer は LP 全体の和紙トーンに揃ったエディトリアル意匠（番号インデックス・大型タイポ・末尾矢印）を持ち、開放中は body スクロールを抑止する。Drawer 末尾には sticky な CTA フッタを配置し、Primary は LINE オープンチャットへの新規タブ遷移、Secondary は `#event-list-heading` へのスムーズスクロールを提供する。
+
+#### Scenario: ハンバーガートリガーの常設
+
+- **WHEN** ユーザーが LP を開いてヘッダーを見たとき
+- **THEN** ヘッダー右端に 2 本線のハンバーガートリガーが表示され、`aria-label="メニューを開く"` `aria-expanded="false"` `aria-controls="<drawer-id>"` が付与されている
+
+#### Scenario: ハンバーガー押下で Drawer が開く
+
+- **WHEN** ユーザーがハンバーガートリガーを押下したとき
+- **THEN** フルスクリーンの Drawer が `opacity 0 → 1` / `translateY(8px) → 0` のアニメーションで表示され、ハンバーガーアイコンが 2 本線 → ✕ に滑らかに変形する。`aria-expanded="true"` / `aria-label="メニューを閉じる"` に切り替わり、Drawer 内の最初のリンクへフォーカスが移る
+
+#### Scenario: Drawer 内ナビゲーションのエディトリアル表示
+
+- **WHEN** Drawer が開かれたとき
+- **THEN** 各ナビ項目が「番号 (01–05) + 日本語ラベル + 末尾矢印 (›)」の 3 カラム構造で縦に並び、項目間は hairline で区切られる。ラベルには `var(--hq-font-jp-display)` が適用される
+
+#### Scenario: Drawer 開放中の body スクロールロック
+
+- **WHEN** Drawer が開かれている間
+- **THEN** `<body>` に `is-locked` クラスが付与され、背景ページのスクロールが抑止される。Drawer インナーは縦スクロール可能で、`overscroll-behavior: contain` によりスクロール伝播が背面に漏れない
+
+#### Scenario: Drawer 末尾の CTA フッタ
+
+- **WHEN** Drawer が開かれたとき
+- **THEN** Drawer 末尾に sticky な CTA フッタが表示される。Primary ボタンは LINE オープンチャット URL へ `target="_blank" rel="noopener noreferrer"` で遷移し、Secondary ボタンは `#event-list-heading` へスムーズスクロールする
+
+#### Scenario: Esc キーで Drawer が閉じる
+
+- **WHEN** Drawer が開かれている状態で Esc キーが押下されたとき
+- **THEN** Drawer が閉じ、フォーカスがハンバーガートリガーに戻る
+
+#### Scenario: ナビリンク押下で Drawer が閉じる
+
+- **WHEN** ユーザーが Drawer 内のいずれかのナビリンクを押下したとき
+- **THEN** 対応するアンカー (`#about-heading` / `#features-heading` / `#flow-heading` / `#event-list-heading` / `#faq-heading`) へスムーズスクロールしながら Drawer が閉じる
+
+#### Scenario: prefers-reduced-motion でアニメーションが抑制される
+
+- **WHEN** OS で「視差効果を減らす」設定が有効なユーザーが Drawer を開閉したとき
+- **THEN** Drawer の opacity / transform トランジションとハンバーガーアイコンの形状トランジションが無効化され、即時の表示・非表示に切り替わる
+
+#### Scenario: Drawer は body 直下にレンダリングされる
+
+- **WHEN** 開発者が DOM ツリーを検査したとき
+- **THEN** Drawer 要素は `<Teleport to="body">` 経由で body 直下に配置され、ヘッダーの stacking context に依存しない
+
+### Requirement: ヘッダーがスクロール量に応じて視覚的に変化する
+
+ヘッダーは、ページ最上部にいる時は透明、スクロール後は不透明＋シャドウ付きで表示されなければならない（SHALL）。Drawer 開放中もヘッダーは不透明状態を維持し、Drawer の paper 背景とヘッダーが視覚的に連続する。
+
+#### Scenario: ページ最上部でのヘッダー透明
+
+- **WHEN** ユーザーが scrollY === 0 の位置にいるとき
+- **THEN** ヘッダーの背景は透明で、Hero 背景画像が透けて見える
+
+#### Scenario: スクロール後のヘッダー不透明
+
+- **WHEN** ユーザーが scrollY > 0 にスクロールしたとき
+- **THEN** ヘッダーの背景は paper 色になり、下端に hairline ボーダーが付く
+
+#### Scenario: Drawer 開放中のヘッダー不透明維持
+
+- **WHEN** Drawer が開かれているとき
+- **THEN** スクロール位置に関わらずヘッダーは paper 背景・ink 文字色を維持し、Drawer 上部と視覚的に連続する

--- a/openspec/changes/archive/2026-05-14-lp-hamburger-drawer-redesign/tasks.md
+++ b/openspec/changes/archive/2026-05-14-lp-hamburger-drawer-redesign/tasks.md
@@ -1,0 +1,39 @@
+## 1. デザイントークン整備
+
+- [x] 1.1 `packages/design-tokens/src/index.ts` に `motion.ease = "cubic-bezier(.22,.61,.36,1)"` を追加し、`build:tokens` で tokens.css に `--hq-motion-ease` を再生成。`src/index.test.ts` に motion 検証を追加
+- [x] 1.2 `pnpm --filter @high-q/design-tokens test` で 12/12 pass。drift 検出により HQ オブジェクト ↔ tokens.css の同期を保証
+
+## 2. SiteHeader.vue の Drawer 化
+
+- [x] 2.1 SiteHeader.vue のインライン展開 `<nav>` を撤去、`<Teleport to="body">` で `.site-drawer` を body 直下に配置
+- [x] 2.2 ハンバーガーを 2 本線アイコン (`.site-header__hamburger-icon` 内に top/bottom bar) に変更、`menuOpen` で `--open` モディファイア付与し ✕ にトランスフォーム。`aria-expanded` / `aria-label` / `aria-controls="site-drawer"` を結線
+- [x] 2.3 ナビ項目を「番号 (01–05) + 大型タイポラベル + ›」の 3 カラム grid で描画。href は 5 アンカーを維持、ラベルはプロトタイプ準拠の文言（はじめての方へ / High Q について / 当日の流れ / 開催スケジュール / よくある質問）に更新
+- [x] 2.4 Drawer footer に Primary `data-testid="drawer-cta-line"` (LINE_OPEN_CHAT_URL / `target="_blank" rel="noopener noreferrer"`) と Secondary `data-testid="drawer-cta-event-list"` (`#event-list-heading`) を配置
+- [x] 2.5 footer 下端に `Tokyo · Koto-ku` / `© 2026 High Q` の meta 行を mono フォント・muted カラーで追加
+
+## 3. 開閉ロジック・アクセシビリティ
+
+- [x] 3.1 `watch(menuOpen)` で `<body>` に `is-locked` class を toggle、Drawer 自身は `:class="{ 'site-drawer--open': menuOpen }"` で同期
+- [x] 3.2 開放時 `nextTick` 後 220ms 遅延で `drawerLinkEls[0]` へフォーカス移動、閉鎖時にハンバーガーへフォーカスを戻す
+- [x] 3.3 Esc keydown で `closeMenu` + ハンバーガーへフォーカス復帰
+- [x] 3.4 ナビリンク / Secondary CTA クリック時に `setTimeout(closeMenu, 80)` でアンカー遷移後に閉じる（Primary LINE は新規タブのため即時 closeMenu）
+- [x] 3.5 `site-header--menu-open` モディファイアで Drawer 開放中はヘッダー paper 背景・ink 文字色を維持（既存 `--scrolled` と同じスタイル分岐）
+
+## 4. CSS 仕上げ
+
+- [x] 4.1 全プロパティを `var(--hq-color-*)` / `var(--hq-font-*)` / `var(--hq-motion-ease)` / `var(--hq-radius-*)` / `var(--hq-shadow-*)` のみで実装。色・イージングのハードコードはオーバーレイ時の subtle text-shadow（プロトタイプ準拠の `rgba(0,0,0,0.x)`）のみに限定
+- [x] 4.2 `.site-drawer__inner` に `overflow-y: auto` + `overscroll-behavior: contain`
+- [x] 4.3 `apps/lp/src/App.vue` のグローバル `<style>` に `body.is-locked { overflow: hidden; }` を追加
+- [x] 4.4 `@media (prefers-reduced-motion: reduce)` で Drawer 自身・リンク・矢印・CTA・ハンバーガーバーのトランジションを `none` に
+
+## 5. テスト
+
+- [x] 5.1 `e2e/lp/site-drawer.e2e.ts` に Drawer happy path E2E を新規追加（ハンバーガー → Drawer 開 → 開催スケジュールリンク押下 → `#event-list-heading` URL + Drawer 閉鎖 + body unlock）
+- [x] 5.2 同ファイルに Drawer footer Primary CTA の LINE URL / target / rel アサーションと Secondary CTA の event-list アサーションを含める
+- [x] 5.3 Esc キーで Drawer 閉鎖 + body unlock を確認するシナリオを追加
+
+## 6. 最終確認
+
+- [x] 6.1 `pnpm --filter @high-q/lp build` 成功（CSS 332.49 kB / JS 459.22 kB / 直前と同水準）
+- [x] 6.2 `pnpm test` で全パッケージ vitest 1490/1490 pass、`pnpm exec playwright test --project=lp` で 12/12 pass（既存 8 件 + 新規 Drawer 4 件）
+- [ ] 6.3 ローカル `pnpm --filter @high-q/lp dev` での目視確認 + Render PR Preview 確認は翔太郎くん側にお願い（PR 作成後に案内）

--- a/openspec/specs/lp-layout/spec.md
+++ b/openspec/specs/lp-layout/spec.md
@@ -19,31 +19,71 @@ Hero セクションには、訪問者を **LP 内のイベント一覧** に誘
 
 ### Requirement: ヘッダーにアンカーナビゲーションが表示される
 
-ヘッダーには CONCEPT / ACTIVITIES / EVENT の3セクションへのアンカーリンクが表示されなければならない（SHALL）。
+ヘッダーにはハンバーガートリガーが常設され、押下するとフルスクリーン Drawer 形式のサイト内ナビゲーションが表示されなければならない（SHALL）。Drawer は LP 全体の和紙トーンに揃ったエディトリアル意匠（番号インデックス・大型タイポ・末尾矢印）を持ち、開放中は body スクロールを抑止する。Drawer 末尾には sticky な CTA フッタを配置し、Primary は LINE オープンチャットへの新規タブ遷移、Secondary は `#event-list-heading` へのスムーズスクロールを提供する。
 
-#### Scenario: md 以上でのアンカー横並び表示
-- **WHEN** ユーザーが md 以上の画面幅で LP を開いたとき
-- **THEN** ヘッダー内に CONCEPT / ACTIVITIES / EVENT のアンカーリンクが横並びで表示される
+#### Scenario: ハンバーガートリガーの常設
 
-#### Scenario: xs/sm でのドロップダウンメニュー表示
-- **WHEN** ユーザーが sm 以下の画面幅で LP を開いたとき
-- **THEN** ヘッダー右にメニューアイコンが表示され、タップすると CONCEPT / ACTIVITIES / EVENT が縦リストで表示される
+- **WHEN** ユーザーが LP を開いてヘッダーを見たとき
+- **THEN** ヘッダー右端に 2 本線のハンバーガートリガーが表示され、`aria-label="メニューを開く"` `aria-expanded="false"` `aria-controls="<drawer-id>"` が付与されている
 
-#### Scenario: アンカーリンク選択時のスムーズスクロール
-- **WHEN** ユーザーがヘッダーのアンカーリンクをクリックしたとき
-- **THEN** 対応するセクション（`#concept` / `#activities` / `#event`）にスムーズスクロールする
+#### Scenario: ハンバーガー押下で Drawer が開く
+
+- **WHEN** ユーザーがハンバーガートリガーを押下したとき
+- **THEN** フルスクリーンの Drawer が `opacity 0 → 1` / `translateY(8px) → 0` のアニメーションで表示され、ハンバーガーアイコンが 2 本線 → ✕ に滑らかに変形する。`aria-expanded="true"` / `aria-label="メニューを閉じる"` に切り替わり、Drawer 内の最初のリンクへフォーカスが移る
+
+#### Scenario: Drawer 内ナビゲーションのエディトリアル表示
+
+- **WHEN** Drawer が開かれたとき
+- **THEN** 各ナビ項目が「番号 (01–05) + 日本語ラベル + 末尾矢印 (›)」の 3 カラム構造で縦に並び、項目間は hairline で区切られる。ラベルには `var(--hq-font-jp-display)` が適用される
+
+#### Scenario: Drawer 開放中の body スクロールロック
+
+- **WHEN** Drawer が開かれている間
+- **THEN** `<body>` に `is-locked` クラスが付与され、背景ページのスクロールが抑止される。Drawer インナーは縦スクロール可能で、`overscroll-behavior: contain` によりスクロール伝播が背面に漏れない
+
+#### Scenario: Drawer 末尾の CTA フッタ
+
+- **WHEN** Drawer が開かれたとき
+- **THEN** Drawer 末尾に sticky な CTA フッタが表示される。Primary ボタンは LINE オープンチャット URL へ `target="_blank" rel="noopener noreferrer"` で遷移し、Secondary ボタンは `#event-list-heading` へスムーズスクロールする
+
+#### Scenario: Esc キーで Drawer が閉じる
+
+- **WHEN** Drawer が開かれている状態で Esc キーが押下されたとき
+- **THEN** Drawer が閉じ、フォーカスがハンバーガートリガーに戻る
+
+#### Scenario: ナビリンク押下で Drawer が閉じる
+
+- **WHEN** ユーザーが Drawer 内のいずれかのナビリンクを押下したとき
+- **THEN** 対応するアンカー (`#about-heading` / `#features-heading` / `#flow-heading` / `#event-list-heading` / `#faq-heading`) へスムーズスクロールしながら Drawer が閉じる
+
+#### Scenario: prefers-reduced-motion でアニメーションが抑制される
+
+- **WHEN** OS で「視差効果を減らす」設定が有効なユーザーが Drawer を開閉したとき
+- **THEN** Drawer の opacity / transform トランジションとハンバーガーアイコンの形状トランジションが無効化され、即時の表示・非表示に切り替わる
+
+#### Scenario: Drawer は body 直下にレンダリングされる
+
+- **WHEN** 開発者が DOM ツリーを検査したとき
+- **THEN** Drawer 要素は `<Teleport to="body">` 経由で body 直下に配置され、ヘッダーの stacking context に依存しない
 
 ### Requirement: ヘッダーがスクロール量に応じて視覚的に変化する
 
-ヘッダーは、ページ最上部にいる時は透明、スクロール後は不透明＋シャドウ付きで表示されなければならない（SHALL）。
+ヘッダーは、ページ最上部にいる時は透明、スクロール後は不透明＋シャドウ付きで表示されなければならない（SHALL）。Drawer 開放中もヘッダーは不透明状態を維持し、Drawer の paper 背景とヘッダーが視覚的に連続する。
 
 #### Scenario: ページ最上部でのヘッダー透明
+
 - **WHEN** ユーザーが scrollY === 0 の位置にいるとき
 - **THEN** ヘッダーの背景は透明で、Hero 背景画像が透けて見える
 
 #### Scenario: スクロール後のヘッダー不透明
+
 - **WHEN** ユーザーが scrollY > 0 にスクロールしたとき
-- **THEN** ヘッダーの背景は primary 色になり、下端に elevation シャドウが付く
+- **THEN** ヘッダーの背景は paper 色になり、下端に hairline ボーダーが付く
+
+#### Scenario: Drawer 開放中のヘッダー不透明維持
+
+- **WHEN** Drawer が開かれているとき
+- **THEN** スクロール位置に関わらずヘッダーは paper 背景・ink 文字色を維持し、Drawer 上部と視覚的に連続する
 
 ### Requirement: ActivitiesSection が HomePage に表示される
 

--- a/packages/design-tokens/src/index.test.ts
+++ b/packages/design-tokens/src/index.test.ts
@@ -82,6 +82,12 @@ describe("HQ design tokens — shadow", () => {
   });
 });
 
+describe("HQ design tokens — motion", () => {
+  it("ease は drawer / overlay 用の cubic-bezier イージング文字列である", () => {
+    expect(HQ.motion.ease).toBe("cubic-bezier(.22,.61,.36,1)");
+  });
+});
+
 describe("HQ design tokens — frozen / immutable", () => {
   it("ルートオブジェクトは凍結されている（誤改変防止）", () => {
     expect(Object.isFrozen(HQ)).toBe(true);

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -60,12 +60,18 @@ const shadow = Object.freeze({
   md: "0 4px 12px rgba(31,29,26,0.06), 0 2px 4px rgba(31,29,26,0.04)",
 });
 
+const motion = Object.freeze({
+  /** 設計サンプル準拠の汎用イージング (drawer / overlay 等のトランジション)。 */
+  ease: "cubic-bezier(.22,.61,.36,1)",
+});
+
 export const HQ = Object.freeze({
   color,
   font,
   space,
   radius,
   shadow,
+  motion,
 });
 
 export type HQColorKey = keyof typeof color;
@@ -73,3 +79,4 @@ export type HQFontKey = keyof typeof font;
 export type HQSpaceKey = keyof typeof space;
 export type HQRadiusKey = keyof typeof radius;
 export type HQShadowKey = keyof typeof shadow;
+export type HQMotionKey = keyof typeof motion;

--- a/packages/design-tokens/src/tokens.css
+++ b/packages/design-tokens/src/tokens.css
@@ -35,4 +35,5 @@
   --hq-shadow-none: none;
   --hq-shadow-sm: 0 1px 2px rgba(31,29,26,0.04), 0 1px 1px rgba(31,29,26,0.06);
   --hq-shadow-md: 0 4px 12px rgba(31,29,26,0.06), 0 2px 4px rgba(31,29,26,0.04);
+  --hq-motion-ease: cubic-bezier(.22,.61,.36,1);
 }


### PR DESCRIPTION
## Summary

- SiteHeader をフルスクリーン Drawer 構造に刷新（Teleport 経由で body 直下、`var(--hq-motion-ease)` でイージング統一）
- ハンバーガーアイコンを 2 本線 → ✕ アニメに、ナビ項目を「番号 (01–05) + 大型タイポ + ›」に変更し、sticky CTA フッタ（LINE primary / event-list secondary）と meta 行を追加
- body スクロール lock / Esc 閉鎖 / 開閉時のフォーカス管理 / `prefers-reduced-motion` 対応

## OpenSpec

- Sync 済み: `openspec/specs/lp-layout/spec.md` の「ヘッダーにアンカーナビゲーション」「スクロール量に応じた変化」要件を Drawer 仕様に更新
- Archive 済み: `openspec/changes/archive/2026-05-14-lp-hamburger-drawer-redesign/`

## Base

`release/lp-redesign-v2`（master ではなく、LP UI 改変リリースブランチに統合）

## Test plan

- [x] `pnpm --filter @high-q/design-tokens test` — 12/12 pass（motion 検証 + drift detect）
- [x] `pnpm test`（全パッケージ）— 1490/1490 pass
- [x] `pnpm exec playwright test --project=lp` — 12/12 pass（既存 8 + 新規 Drawer 4）
- [x] `pnpm --filter @high-q/lp build` — 成功（CSS 332 kB / JS 459 kB）
- [ ] Render PR Preview で Drawer の見た目・開閉アニメ・body lock・LINE/event-list 遷移を Chrome 実機で目視確認

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)