### PR TITLE
fix(edge-functions): signup 系 Function の verify_jwt=false を config.toml に永続化

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -380,6 +380,19 @@ deno_version = 2
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 
+# -----------------------------------------------------------------------------
+# 個別 Edge Function の設定
+# -----------------------------------------------------------------------------
+# verify_jwt = false: クライアントから Authorization header / JWT 無しで呼べる。
+# signup フロー（未認証ユーザーが叩く）は false が必須。CLI からの deploy 時に
+# `--no-verify-jwt` flag 付け忘れで verify_jwt が true に戻る事故を防ぐため
+# ソース管理する。
+[functions.request-signup]
+verify_jwt = false
+
+[functions.verify-signup]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327


### PR DESCRIPTION
## Summary

#281 ship 中に発生した本番 signup 401 Unauthorized 問題の **再発防止コミット**。

- `supabase functions deploy request-signup` を ship 中に実行した際、`--no-verify-jwt` flag を付け忘れたため Function の `verify_jwt` が default の true に戻り、prd で signup フォームが 401 Unauthorized を返すようになった
- Function 自体は本 PR とは別に手動で `--no-verify-jwt` 付きで再 deploy 済（既に prd で signup 動作復旧確認済）
- 本 PR は `supabase/config.toml` に `[functions.request-signup]` / `[functions.verify-signup]` の `verify_jwt = false` を明示宣言し、今後 flag を付け忘れても source-of-truth から再生される状態にする

## Why verify_jwt = false?

signup フローは **未認証ユーザー** が叩く Edge Function。JWT verify を有効にすると anon key / 認証ヘッダ無しでは到達できず、フォーム送信が永続的に 401 になる。`request-signup` / `verify-signup` 内部で payload バリデーション + 既登録チェック + レート制限を担保しているため、JWT verify は不要かつ阻害要因。

## Test plan

- [x] prd で `request-signup` を `--no-verify-jwt` 付き手動 deploy 済 → 401 解消確認
- [x] curl 直叩きで HTTP 400 (validation-error) が返り、401 が出ないことを確認
- [ ] master merge 後、将来の deploy で config.toml の設定が読み込まれて verify_jwt=false が維持されることを期待

## Related

- 元 PR: #292 (Issue #281 会員登録の氏名入力を姓・名 2 フィールドに分離)
- 本 PR は #292 の post-ship hotfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
