### PR TITLE
fix(infra): backup-prd.yml に data + roles ダンプを追加 (#299 空 backup 修正)

### DIFF
--- a/.github/workflows/backup-prd.yml
+++ b/.github/workflows/backup-prd.yml
@@ -55,44 +55,83 @@ jobs:
       - name: Link to prd Supabase project
         run: pnpm exec supabase link --project-ref "${{ secrets.SUPABASE_PRD_PROJECT_REF }}"
 
-      - name: Compute dump file name and timestamp
+      - name: Compute dump file names and timestamp
         id: meta
         run: |
           TS="$(date -u +%Y%m%d_%H%M%S)"
-          DUMP_FILE="prd_${TS}.sql"
+          SCHEMA_FILE="prd_${TS}_schema.sql"
+          DATA_FILE="prd_${TS}_data.sql"
+          ROLES_FILE="prd_${TS}_roles.sql"
           ARTIFACT_NAME="prd-backup-${TS}"
           {
             echo "timestamp=${TS}"
-            echo "dump_file=${DUMP_FILE}"
+            echo "schema_file=${SCHEMA_FILE}"
+            echo "data_file=${DATA_FILE}"
+            echo "roles_file=${ROLES_FILE}"
             echo "artifact_name=${ARTIFACT_NAME}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Dump prd Supabase (public + auth schemas, schema + data)
+      - name: Dump schema (DDL only, public + auth)
         run: |
           pnpm exec supabase db dump \
             --linked \
             --schema public \
             --schema auth \
-            -f "${{ steps.meta.outputs.dump_file }}"
+            -f "${{ steps.meta.outputs.schema_file }}"
+
+      - name: Dump data (COPY format, public + auth, excluding noisy auth audit tables)
+        run: |
+          pnpm exec supabase db dump \
+            --linked \
+            --data-only \
+            --use-copy \
+            --schema public \
+            --schema auth \
+            --exclude 'auth.audit_log_entries' \
+            --exclude 'auth.flow_state' \
+            --exclude 'auth.refresh_tokens' \
+            --exclude 'auth.sessions' \
+            --exclude 'auth.one_time_tokens' \
+            -f "${{ steps.meta.outputs.data_file }}"
+
+      - name: Dump cluster roles (auth.users 復元時に必要なロール定義)
+        run: |
+          pnpm exec supabase db dump \
+            --linked \
+            --role-only \
+            -f "${{ steps.meta.outputs.roles_file }}"
 
       - name: Inspect dump file metadata (no content leak)
         id: inspect
         run: |
-          DUMP_FILE="${{ steps.meta.outputs.dump_file }}"
-          SIZE_BYTES=$(wc -c < "$DUMP_FILE")
-          SIZE_HUMAN=$(du -h "$DUMP_FILE" | awk '{print $1}')
-          LINE_COUNT=$(wc -l < "$DUMP_FILE")
+          SCHEMA_FILE="${{ steps.meta.outputs.schema_file }}"
+          DATA_FILE="${{ steps.meta.outputs.data_file }}"
+          ROLES_FILE="${{ steps.meta.outputs.roles_file }}"
+          SCHEMA_SIZE=$(du -h "$SCHEMA_FILE" | awk '{print $1}')
+          DATA_SIZE=$(du -h "$DATA_FILE" | awk '{print $1}')
+          ROLES_SIZE=$(du -h "$ROLES_FILE" | awk '{print $1}')
+          SCHEMA_LINES=$(wc -l < "$SCHEMA_FILE")
+          DATA_LINES=$(wc -l < "$DATA_FILE")
+          ROLES_LINES=$(wc -l < "$ROLES_FILE")
+          TOTAL_BYTES=$(( $(wc -c < "$SCHEMA_FILE") + $(wc -c < "$DATA_FILE") + $(wc -c < "$ROLES_FILE") ))
           {
-            echo "size_bytes=${SIZE_BYTES}"
-            echo "size_human=${SIZE_HUMAN}"
-            echo "line_count=${LINE_COUNT}"
+            echo "schema_size=${SCHEMA_SIZE}"
+            echo "data_size=${DATA_SIZE}"
+            echo "roles_size=${ROLES_SIZE}"
+            echo "schema_lines=${SCHEMA_LINES}"
+            echo "data_lines=${DATA_LINES}"
+            echo "roles_lines=${ROLES_LINES}"
+            echo "total_bytes=${TOTAL_BYTES}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Upload dump to GitHub Artifacts (retention 90 days)
+      - name: Upload dump set to GitHub Artifacts (retention 90 days)
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.meta.outputs.artifact_name }}
-          path: ${{ steps.meta.outputs.dump_file }}
+          path: |
+            ${{ steps.meta.outputs.schema_file }}
+            ${{ steps.meta.outputs.data_file }}
+            ${{ steps.meta.outputs.roles_file }}
           retention-days: 90
           if-no-files-found: error
 
@@ -109,17 +148,30 @@ jobs:
             fi
             echo "- Commit SHA: \`${{ github.sha }}\`"
             echo "- Ref: \`${{ github.ref }}\`"
-            echo "- Dump file: \`${{ steps.meta.outputs.dump_file }}\`"
             echo "- Artifact: \`${{ steps.meta.outputs.artifact_name }}\` (retention 90 days)"
-            echo "- Size: ${{ steps.inspect.outputs.size_human }} (${{ steps.inspect.outputs.size_bytes }} bytes)"
-            echo "- Line count: ${{ steps.inspect.outputs.line_count }}"
             echo ""
-            echo "### Schemas included"
+            echo "### Dump files (3 ファイル構成)"
             echo ""
-            echo "- \`public\` (アプリケーション全データ: members / reservations / identity_documents / events / venues 等)"
-            echo "- \`auth\` (Supabase Auth: auth.users 等、members の FK 整合確保)"
+            echo "| ファイル | 内容 | サイズ | 行数 |"
+            echo "|---|---|---|---|"
+            echo "| \`${{ steps.meta.outputs.schema_file }}\` | スキーマ (DDL: CREATE TABLE / FUNCTION / POLICY 等) | ${{ steps.inspect.outputs.schema_size }} | ${{ steps.inspect.outputs.schema_lines }} |"
+            echo "| \`${{ steps.meta.outputs.data_file }}\` | データ (COPY 形式、auth audit/session 系除外) | ${{ steps.inspect.outputs.data_size }} | ${{ steps.inspect.outputs.data_lines }} |"
+            echo "| \`${{ steps.meta.outputs.roles_file }}\` | クラスタロール (auth.users 復元時に必要) | ${{ steps.inspect.outputs.roles_size }} | ${{ steps.inspect.outputs.roles_lines }} |"
             echo ""
-            echo "### Restore"
+            echo "Total bytes: ${{ steps.inspect.outputs.total_bytes }}"
             echo ""
-            echo "復旧手順は \`docs/06-品質・セキュリティ/14-バックアップ復旧SOP.md\` § 7.2 を参照。"
+            echo "### Schemas / Tables included"
+            echo ""
+            echo "- \`public\` 全テーブル (members / reservations / identity_documents / events / venues / signup_pending)"
+            echo "- \`auth.users\` (会員アカウント、members FK 整合確保)"
+            echo "- \`auth\` のその他 OAuth/MFA/identities 関連テーブル"
+            echo "- 除外: \`auth.audit_log_entries\` / \`auth.flow_state\` / \`auth.refresh_tokens\` / \`auth.sessions\` / \`auth.one_time_tokens\` (session/audit ノイズ、復旧目的に不要、サイズ肥大の主因)"
+            echo ""
+            echo "### Restore order"
+            echo ""
+            echo "1. \`<timestamp>_roles.sql\` (クラスタロール、既存と重複時は無視)"
+            echo "2. \`<timestamp>_schema.sql\` (DDL を空 DB に適用)"
+            echo "3. \`<timestamp>_data.sql\` (COPY でデータ流し込み)"
+            echo ""
+            echo "詳細復旧手順は \`docs/06-品質・セキュリティ/14-バックアップ復旧SOP.md\` § 7.2 を参照。"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/06-品質・セキュリティ/14-バックアップ復旧SOP.md
+++ b/docs/06-品質・セキュリティ/14-バックアップ復旧SOP.md
@@ -236,26 +236,33 @@ prd で障害が発生した場合の復旧手段を 3 観点で整理する。�
 ### 7.2 DB 層の障害: GitHub Actions 自動 pg_dump からの restore
 
 - 症状: migration 適用後にデータ破損 / アプリエラーが多発
-- 前提: 本 SOP 公開後、`.github/workflows/backup-prd.yml` (#299) が週次自動 pg_dump を取得し GitHub Artifacts に 90 日保持している。dump は `public` + `auth` の 2 スキーマを含み、`auth.users` と `members` の FK 整合を保ったまま restore 可能
+- 前提: 本 SOP 公開後、`.github/workflows/backup-prd.yml` (#299) が週次自動 pg_dump を取得し GitHub Artifacts に 90 日保持している。dump は `public` + `auth` の 2 スキーマを含み、`auth.users` と `members` の FK 整合を保ったまま restore 可能。Artifact は **3 ファイル構成** (schema / data / roles) で、`supabase db dump` のデフォルトが schema-only であるため明示的に data も別ファイルで取得している
+- Artifact ファイル構成 (1 つの `prd-backup-<YYYYMMDD_HHMMSS>` artifact 内に同梱):
+  - `prd_<YYYYMMDD_HHMMSS>_schema.sql`: スキーマ DDL (CREATE TABLE / FUNCTION / TRIGGER / POLICY / GRANT 等)
+  - `prd_<YYYYMMDD_HHMMSS>_data.sql`: COPY 形式のデータ本体 (`public` 全テーブル + `auth.users` 等)。`auth.audit_log_entries` / `flow_state` / `refresh_tokens` / `sessions` / `one_time_tokens` は除外 (session/audit ノイズで復旧目的不要)
+  - `prd_<YYYYMMDD_HHMMSS>_roles.sql`: クラスタロール定義 (`auth.users` の OWNER 再現に必要)
 - 対応 (Free プラン、GitHub Actions Artifacts からの restore 手順):
   1. **dump の取得**:
      - GitHub リポジトリ → "Actions" タブ → 左ペインから `backup prd Supabase (weekly pg_dump)` ワークフローを選択
      - run 一覧から障害発生直前の正常 run を開く (90 日以内のものから選択)
-     - run ページ下部の "Artifacts" セクションで `prd-backup-<YYYYMMDD_HHMMSS>` を翔太郎くんローカル端末にダウンロード (zip 形式で配布される)
-     - ダウンロードした zip を展開し `prd_<YYYYMMDD_HHMMSS>.sql` を取り出す
+     - run ページ下部の "Artifacts" セクションで `prd-backup-<YYYYMMDD_HHMMSS>` を翔太郎くんローカル端末にダウンロード (zip 形式で配布、3 ファイル同梱)
+     - ダウンロードした zip を展開し `_schema.sql` / `_data.sql` / `_roles.sql` の 3 ファイルを取り出す
   2. **dev で動作確認 (必須)**:
-     - 取り出した dump を翔太郎くん dev 端末で `~/Documents/high-q-backups/restore-staging/` 等に一時配置
+     - 取り出した dump 群を翔太郎くん dev 端末で `~/Documents/high-q-backups/restore-staging/` 等に一時配置
      - dev プロジェクトを `supabase db reset --linked` 等で初期化 (dev データ消失を許容)
-     - `psql` または Supabase Dashboard の SQL Editor で dump を dev に restore
+     - 以下の順序で `psql` または Supabase Dashboard の SQL Editor で dev に restore:
+       1. `_roles.sql` (クラスタロール、既存と重複時の `already exists` エラーは無視)
+       2. `_schema.sql` (DDL)
+       3. `_data.sql` (COPY でデータ流し込み)
      - dev URL (PR Preview または `pnpm dev`) でアプリ起動、会員ジャーニーが正常動作することを確認
   3. **prd 上書き前の保険スナップショット**:
      - 上書き直前の prd 状態を § 3 の手動 pg_dump 手順で別途バックアップ取得 (`prd_pre_<YYYYMMDD_HHMMSS>_emergency_restore.sql`)
      - 上書き失敗時のロールバック手段として保持
   4. **prd への restore**:
      - psql で慎重に実施。Supabase Dashboard 経由 SQL Editor は大規模 dump に不向きなため psql を推奨
-     - 既存スキーマ削除 → dump 流し込みの順序、トランザクション境界に注意
+     - 既存スキーマ削除 → roles → schema → data の順序、トランザクション境界に注意
   5. **復旧後のアプリ動作確認**: 管理画面・予約サイト双方で会員データ・予約データ・本人確認書類画像参照が正常動作することを確認
-  6. **ダウンロードした dump の事後処理**: 復旧完了後、ローカル端末上の dump ファイル (取り出した `.sql` および展開元 zip) は速やかに削除。**GitHub / Slack / メール / Claude へのチャットペースト等で外部送信しない MUST** (§ 3.3 と同じアクセス制御原則)
+  6. **ダウンロードした dump の事後処理**: 復旧完了後、ローカル端末上の dump ファイル群 (取り出した `.sql` および展開元 zip) は速やかに削除。**GitHub / Slack / メール / Claude へのチャットペースト等で外部送信しない MUST** (§ 3.3 と同じアクセス制御原則)
 - 対応 (Pro プラン昇格後): Supabase PITR で障害発生直前の任意時点に復旧可能 (RPO 短縮)
 - 所要時間: 数十分〜数時間 (DB サイズに依存)
 - **重要な制約**:
@@ -371,3 +378,4 @@ prd で障害が発生した場合の復旧手段を 3 観点で整理する。�
 |---|---|---|
 | 2026-05-24 | 初版作成。Issue #269 対応として Supabase 自動バックアップ仕様 / Pro プラン昇格判断 / 重要 migration 適用前 pg_dump 手順 / migration 3 分類運用ルール / 既存 21 件をカテゴリ 3 一括宣言 / 復旧手順 / 障害時復旧フロー / 漏洩時 SOP 連携 / 法令準拠根拠 / MVP3 オフロード項目 を明文化 | 翔太郎くん / レム |
 | 2026-05-25 | Issue #299 対応として GitHub Actions 週次自動 pg_dump ワークフロー (`backup-prd.yml`) を実装、§ 7.2 に Artifacts ダウンロードからの restore 詳細手順 (前提・90 日制約・アクセス権)・§ 10.1 を「実装済み」表現に更新、SOP 全体の「導入予定」未来形表現を「実装済み・運用中」現在形に変換 | 翔太郎くん / レム |
+| 2026-05-25 | #299 動作確認で `supabase db dump` がデフォルト schema-only である仕様判明、data が含まれない不具合を発見し fix。ワークフローを schema / data / roles の 3 ダンプ構成に変更、§ 7.2 の restore 手順も roles → schema → data の 3 ステップに更新 | 翔太郎くん / レム |


### PR DESCRIPTION
## Summary

#299 (PR #301) でマージした `backup-prd.yml` の **空 backup 不具合** を修正します。merge 後の動作確認で取得した dump に `INSERT`/`COPY` 行が 1 件も含まれず、`auth.users` / `members` / `venues` 等のデータが完全に欠落していたため、本来の backup 目的 (会員データ復旧) を果たせていませんでした。

## 根本原因

`supabase db dump --linked --schema <name>` は **デフォルト schema-only (DDL のみ)** で、データを含めるには `--data-only --use-copy` を別実行する必要があります。design.md には「data + schema 両方を含める」と書きながら、実装で `--data-only` を入れずに 1 回呼びにしてしまった仕様確認漏れです。

## 修正内容

### `.github/workflows/backup-prd.yml`

dump 取得を 3 ステップに分割:

| ステップ | コマンド | 出力 |
|---|---|---|
| 1. schema | `supabase db dump --linked --schema public --schema auth` | `prd_<ts>_schema.sql` (DDL) |
| 2. data | `supabase db dump --linked --data-only --use-copy --schema public --schema auth` + 5 つの `--exclude` | `prd_<ts>_data.sql` (COPY 形式データ) |
| 3. roles | `supabase db dump --linked --role-only` | `prd_<ts>_roles.sql` (クラスタロール) |

#### data dump で除外するテーブル

session / audit ノイズで肥大化の主因、復旧目的不要:
- `auth.audit_log_entries`
- `auth.flow_state`
- `auth.refresh_tokens`
- `auth.sessions`
- `auth.one_time_tokens`

3 ファイルは単一 Artifact (`prd-backup-<ts>`) に同梱、retention 90 日は維持。

Step Summary もファイル別サイズ・行数表示に拡張し、restore 順序 (roles → schema → data) を明示。

### `docs/06-品質・セキュリティ/14-バックアップ復旧SOP.md` § 7.2

- Artifact が 3 ファイル構成であることを前提として明記
- restore 手順を **roles → schema → data の 3 ステップ** に更新
- 改訂履歴に本修正エントリを追加

## Test plan (memory `feedback_github_actions_new_workflow_merge_caveat` に準拠した 2 段運用)

### Stage 1: マージ前 (本 PR でレビュー)

- [x] yaml syntax check (node + js-yaml) で 14 steps 構造確認
- [x] `supabase db dump --help` で `--data-only` / `--use-copy` / `--role-only` / `--exclude` の仕様確認
- [ ] 既存 CI (`.github/workflows/ci.yml`) の全 job が緑
- [ ] `db-push-prd.yml` が本 PR で起動しないこと

### Stage 2: マージ後 (翔太郎くん実施)

- [ ] master へマージされたら `backup prd Supabase (weekly pg_dump)` の最新 workflow を `workflow_dispatch` で手動実行
- [ ] 以下を順に確認:
  - [ ] run が SUCCESS で完了
  - [ ] Artifacts に `prd-backup-<ts>` が表示され、ダウンロード zip に **3 ファイル** (`_schema.sql` / `_data.sql` / `_roles.sql`) が含まれる
  - [ ] `_schema.sql` 先頭に `CREATE SCHEMA IF NOT EXISTS auth;` 等の DDL あり (前回と同じ)
  - [ ] **`_data.sql` 先頭/中盤に `COPY public.members` / `COPY auth.users` / `COPY public.venues` 等の COPY 行とその実データが含まれる** ← 今回の修正の核心
  - [ ] `_roles.sql` に `CREATE ROLE supabase_auth_admin` 等のロール定義あり
  - [ ] Step Summary にファイル別サイズ・行数・restore 順序が表示される
- [ ] 確認後、ダウンロードした dump 群はローカルから即削除 (SOP § 7.2 アクセス制御原則)

## 関連 memory への記録

- 新規: `feedback_supabase_db_dump_default_schema_only` — supabase db dump はデフォルト schema-only、3 ファイル運用が必要

## Notes

- 本 PR も prd Supabase に対し **読み取り操作のみ** (`supabase db dump`)。書き込み・DDL は一切含まない
- #299 / #301 は既に master 反映済みで Issue クローズ済み。本 PR は #299 の修復扱い (新規 Issue 起票はせず Refs #299 とする)
- dump サイズが 3 ファイル化で約 1.5〜2 倍になる見込み (data 込みのため)。GitHub Artifacts 無制限のため問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)