### PR TITLE
chore(infra): setup-worktree.sh に --open-vscode フラグ追加 (#330)

### DIFF
--- a/.claude/skills/start-parallel-dev/SKILL.md
+++ b/.claude/skills/start-parallel-dev/SKILL.md
@@ -90,7 +90,7 @@ master + dirty なら、setup-worktree.sh が `--force-main` 無しでブロッ�
 
 ```bash
 cd ~/Desktop/high-q-volleyball
-scripts/dev/setup-worktree.sh <issue番号> <slug> [--type=feature|fix|chore]
+scripts/dev/setup-worktree.sh <issue番号> <slug> [--type=feature|fix|chore] [--open-vscode]
 ```
 
 例:
@@ -98,7 +98,10 @@ scripts/dev/setup-worktree.sh <issue番号> <slug> [--type=feature|fix|chore]
 ```bash
 scripts/dev/setup-worktree.sh 329 add-foo
 scripts/dev/setup-worktree.sh 330 fix-bar --type=fix
+scripts/dev/setup-worktree.sh 331 add-baz --open-vscode   # 新規 VS Code ウィンドウで起動
 ```
+
+並列で別 Claude セッションを立ち上げる流れだと VS Code ウィンドウも別で開きたいケースが多いので、翔太郎くんの意図が明確に並列セッション開始であれば `--open-vscode` 付与を提案する。
 
 ### Step 5: 新規 worktree で別 Claude セッション起動を案内
 

--- a/docs/03-アーキテクチャ/07-並列開発ガイド.md
+++ b/docs/03-アーキテクチャ/07-並列開発ガイド.md
@@ -134,7 +134,7 @@ cat openspec/changes/<name>/proposal.md | grep -A 5 "Capabilities"
 ### 7.1 `scripts/dev/setup-worktree.sh`
 
 ```bash
-scripts/dev/setup-worktree.sh <issue番号> <slug> [--type=feature|fix|chore] [--force-main]
+scripts/dev/setup-worktree.sh <issue番号> <slug> [--type=feature|fix|chore] [--force-main] [--open-vscode]
 ```
 
 実行内容:
@@ -145,13 +145,20 @@ scripts/dev/setup-worktree.sh <issue番号> <slug> [--type=feature|fix|chore] [-
 4. `git worktree add ../high-q-volleyball-wt-<issue> -b <type>/<issue>-<slug> origin/master`
 5. worktree 内で `pnpm install`
 6. ポート計算 (既存 worktree 数 N から `BASE + 100*N`)
-7. 起動コマンド / URL / 注意事項を整形表示
+7. `--open-vscode` 指定時は worktree を新規 VS Code ウィンドウで起動 (`code -n`)
+8. 起動コマンド / URL / 注意事項を整形表示
 
 引数検証:
 
 - Issue 番号: `^[0-9]+$`
 - slug: `^[a-z0-9-]+$`
 - type: `feature|fix|chore` (デフォルト `feature`)
+
+`--open-vscode` (`--code` でも可) の挙動:
+
+- PATH 上の `code` → `/Applications/Visual Studio Code.app/.../bin/code` → `open -na "Visual Studio Code"` の順にフォールバック
+- VS Code が見つからなければ WARN を出してスキップ (worktree 作成自体は成功扱い)
+- 手動で開きたい時は `code -n ../high-q-volleyball-wt-<issue>` でも可
 
 ### 7.2 `scripts/dev/teardown-worktree.sh`
 

--- a/scripts/dev/setup-worktree.sh
+++ b/scripts/dev/setup-worktree.sh
@@ -3,11 +3,12 @@
 # setup-worktree.sh — 2 並列開発用の git worktree を 1 コマンドで構築する
 #
 # 使い方:
-#   scripts/dev/setup-worktree.sh <issue番号> <slug> [--type=feature|fix|chore] [--force-main]
+#   scripts/dev/setup-worktree.sh <issue番号> <slug> [--type=feature|fix|chore] [--force-main] [--open-vscode]
 #
 # 例:
 #   scripts/dev/setup-worktree.sh 329 add-foo
 #   scripts/dev/setup-worktree.sh 330 fix-bar --type=fix
+#   scripts/dev/setup-worktree.sh 331 add-baz --open-vscode
 #
 # 詳細は docs/03-アーキテクチャ/07-並列開発ガイド.md 参照。
 
@@ -23,7 +24,7 @@ PORT_STEP=100
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") <issue番号> <slug> [--type=feature|fix|chore] [--force-main]
+Usage: $(basename "$0") <issue番号> <slug> [--type=feature|fix|chore] [--force-main] [--open-vscode]
 
 Arguments:
   <issue番号>     GitHub Issue 番号 (数値のみ)
@@ -32,16 +33,19 @@ Arguments:
 Options:
   --type=TYPE     ブランチ prefix (feature|fix|chore, default: feature)
   --force-main    メインリポジトリが master + dirty でも続行する
+  --open-vscode   セットアップ完了後に worktree を新規 VS Code ウィンドウで開く
 
 Example:
   $(basename "$0") 329 add-foo
   $(basename "$0") 330 fix-bar --type=fix
+  $(basename "$0") 331 add-baz --open-vscode
 EOF
 }
 
 # ---- 引数パース --------------------------------------------------------------
 TYPE="feature"
 FORCE_MAIN=0
+OPEN_VSCODE=0
 POSITIONAL=()
 
 for arg in "$@"; do
@@ -51,6 +55,9 @@ for arg in "$@"; do
       ;;
     --force-main)
       FORCE_MAIN=1
+      ;;
+    --open-vscode|--code)
+      OPEN_VSCODE=1
       ;;
     -h|--help)
       usage
@@ -154,6 +161,29 @@ WT_INDEX="$((WT_COUNT - 1))"  # メインを除いた index (新規分が N 番�
 ADMIN_PORT="$((BASE_PORT_ADMIN + PORT_STEP * WT_INDEX))"
 RESERVATION_PORT="$((BASE_PORT_RESERVATION + PORT_STEP * WT_INDEX))"
 
+# ---- VS Code 起動 (任意) -----------------------------------------------------
+VSCODE_OPENED=0
+if [ "$OPEN_VSCODE" -eq 1 ]; then
+  CODE_BIN=""
+  if command -v code >/dev/null 2>&1; then
+    CODE_BIN="code"
+  elif [ -x "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" ]; then
+    CODE_BIN="/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+  fi
+
+  if [ -n "$CODE_BIN" ]; then
+    echo "==> VS Code を新規ウィンドウで起動: ${WT_PATH}"
+    "$CODE_BIN" -n "$WT_PATH"
+    VSCODE_OPENED=1
+  elif [ -d "/Applications/Visual Studio Code.app" ]; then
+    echo "==> VS Code を新規ウィンドウで起動: ${WT_PATH}"
+    open -na "Visual Studio Code" --args "$WT_PATH"
+    VSCODE_OPENED=1
+  else
+    echo "WARN: VS Code が見つからないため --open-vscode をスキップしました" >&2
+  fi
+fi
+
 # ---- 完了サマリ --------------------------------------------------------------
 cat <<EOF
 
@@ -177,6 +207,9 @@ worktree #:   ${WT_INDEX}
   1. cd ${WT_PATH}
   2. このディレクトリで別の Claude セッションを起動
   3. 最新を取り込みたい時: git fetch origin && git merge origin/master
+
+▼ VS Code を別ウィンドウで開きたい時
+  $([ "$VSCODE_OPENED" -eq 1 ] && echo "(--open-vscode 指定により起動済み)" || echo "code -n ${WT_PATH}    # PATH 未通の場合: 再実行時に --open-vscode を付与")
 
 ▼ 注意
   - master を直接 checkout しないこと (両 worktree で feature ブランチ常駐)


### PR DESCRIPTION
## Summary
- `scripts/dev/setup-worktree.sh` に `--open-vscode` (`--code`) フラグを追加
- VS Code 起動は `code` (PATH) → `/Applications/Visual Studio Code.app/.../bin/code` → `open -na "Visual Studio Code"` の 3 段フォールバック
- 並列開発ガイド 7.1 節 / `start-parallel-dev` SKILL Step 4 を同期更新

## Why
#328「2 並列開発を再現可能にする worktree セットアップ + Skill 整備」で並列開発インフラを整備したが、別 Claude セッション立ち上げ時に毎回手動で VS Code ウィンドウを開く手数が残っていた。スクリプトに同梱することで `/start-parallel-dev` Skill 経由で 1 行追加するだけで完結する。

Closes #330

## Test plan
- [x] `bash -n scripts/dev/setup-worktree.sh` 構文 OK
- [x] `scripts/dev/setup-worktree.sh --help` に `--open-vscode` が表示される
- [x] フラグ無しで wt-247 を作成済み、後追いで `code -n` 起動が動作することを実機確認
- [ ] レビュー時に `scripts/dev/setup-worktree.sh <test#> test-slug --open-vscode` で worktree が新規 VS Code ウィンドウに開くことを確認 (merge 前のローカル試験)
- [ ] VS Code 未インストール環境シミュレーション (手動 PATH unset) で WARN ログのみ出て worktree 作成自体は成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)